### PR TITLE
Add runtime language switching support

### DIFF
--- a/Bonfire/AppShell/BonfireApp.swift
+++ b/Bonfire/AppShell/BonfireApp.swift
@@ -2,9 +2,13 @@ import SwiftUI
 
 @main
 struct BonfireApp: App {
+    @StateObject private var languageManager = LanguageManager()
+
     var body: some Scene {
         WindowGroup {
             RootTabView()
+                .environmentObject(languageManager)
+                .environment(\.locale, languageManager.locale)
         }
     }
 }

--- a/Bonfire/AppShell/ProfileView.swift
+++ b/Bonfire/AppShell/ProfileView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct ProfileView: View {
+    @EnvironmentObject private var languageManager: LanguageManager
+    @State private var selectedLanguage: AppLanguage = .english
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text(LocalizedStringKey("settings.section.language"))) {
+                    Picker(LocalizedStringKey("settings.language"), selection: $selectedLanguage) {
+                        ForEach(AppLanguage.allCases) { language in
+                            Text(language.localizedNameKey)
+                                .tag(language)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+            }
+            .navigationTitle(LocalizedStringKey("settings.title"))
+        }
+        .onAppear {
+            selectedLanguage = languageManager.currentLanguage
+        }
+        .onChange(of: selectedLanguage) { newValue in
+            languageManager.setLanguage(newValue)
+        }
+    }
+}
+
+struct ProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProfileView()
+            .environmentObject(LanguageManager())
+    }
+}

--- a/Bonfire/AppShell/RootTabView.swift
+++ b/Bonfire/AppShell/RootTabView.swift
@@ -6,7 +6,7 @@ struct RootTabView: View {
     var body: some View {
         TabView(selection: $selection) {
             ForEach(RootTab.allCases) { tab in
-                PlaceholderView(titleKey: tab.titleKey)
+                tab.destination
                     .tabItem {
                         Label(tab.titleKey, systemImage: tab.systemImage)
                     }
@@ -58,6 +58,16 @@ private enum RootTab: String, CaseIterable, Identifiable {
         }
     }
 
+    @ViewBuilder
+    var destination: some View {
+        switch self {
+        case .profile:
+            ProfileView()
+        case .reader, .audio, .vocab:
+            PlaceholderView(titleKey: titleKey)
+        }
+    }
+
     var systemImage: String {
         switch self {
         case .reader:
@@ -75,5 +85,6 @@ private enum RootTab: String, CaseIterable, Identifiable {
 struct RootTabView_Previews: PreviewProvider {
     static var previews: some View {
         RootTabView()
+            .environmentObject(LanguageManager())
     }
 }

--- a/Bonfire/Base.lproj/Localizable.strings
+++ b/Bonfire/Base.lproj/Localizable.strings
@@ -1,5 +1,0 @@
-"tab.reader" = "Reader";
-"tab.audio" = "Audio";
-"tab.vocab" = "Vocab";
-"tab.profile" = "Profile";
-"placeholder.comingSoon" = "Coming soon";

--- a/Bonfire/Utilities/LanguageManager.swift
+++ b/Bonfire/Utilities/LanguageManager.swift
@@ -1,0 +1,51 @@
+import Foundation
+import SwiftUI
+
+enum AppLanguage: String, CaseIterable, Identifiable {
+    case english = "en"
+    case vietnamese = "vi"
+
+    var id: String { rawValue }
+
+    var localeIdentifier: String { rawValue }
+
+    var localizedNameKey: LocalizedStringKey {
+        switch self {
+        case .english:
+            return LocalizedStringKey("language.english")
+        case .vietnamese:
+            return LocalizedStringKey("language.vietnamese")
+        }
+    }
+}
+
+final class LanguageManager: ObservableObject {
+    @Published private(set) var currentLanguage: AppLanguage
+    @Published private(set) var locale: Locale
+
+    private let userDefaults: UserDefaults
+    private let storageKey = "app.selectedLanguage"
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+
+        if
+            let identifier = userDefaults.string(forKey: storageKey),
+            let savedLanguage = AppLanguage(rawValue: identifier)
+        {
+            currentLanguage = savedLanguage
+        } else {
+            currentLanguage = .english
+        }
+
+        locale = Locale(identifier: currentLanguage.localeIdentifier)
+    }
+
+    func setLanguage(_ language: AppLanguage) {
+        guard language != currentLanguage else { return }
+
+        currentLanguage = language
+        locale = Locale(identifier: language.localeIdentifier)
+        userDefaults.set(language.rawValue, forKey: storageKey)
+    }
+}

--- a/Bonfire/en.lproj/Localizable.strings
+++ b/Bonfire/en.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"tab.reader" = "Reader";
+"tab.audio" = "Audio";
+"tab.vocab" = "Vocab";
+"tab.profile" = "Profile";
+"placeholder.comingSoon" = "Coming soon";
+"settings.title" = "Settings";
+"settings.section.language" = "Language";
+"settings.language" = "App Language";
+"language.english" = "English";
+"language.vietnamese" = "Vietnamese";

--- a/Bonfire/vi.lproj/Localizable.strings
+++ b/Bonfire/vi.lproj/Localizable.strings
@@ -3,3 +3,8 @@
 "tab.vocab" = "Từ vựng";
 "tab.profile" = "Hồ sơ";
 "placeholder.comingSoon" = "Sắp ra mắt";
+"settings.title" = "Cài đặt";
+"settings.section.language" = "Ngôn ngữ";
+"settings.language" = "Ngôn ngữ ứng dụng";
+"language.english" = "Tiếng Anh";
+"language.vietnamese" = "Tiếng Việt";


### PR DESCRIPTION
## Summary
- add a shared LanguageManager to persist the selected locale and update the SwiftUI environment
- expose a settings form on the profile tab with an English/Vietnamese picker and segmented control
- migrate strings to en/vi Localizable files and translate the new settings copy

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68db8e571c888331af6d5baac3835908