### PR TITLE
Switch texture placeholders to procedural SwiftUI and ignore binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ playground.xcworkspace
 *.swp
 *.swo
 .DS_Store
+
+# Generated binary assets
+*.xcassets/**/*.png
+*.xcassets/**/*.jpg
+*.xcassets/**/*.jpeg
+*.xcassets/**/*.pdf

--- a/Bonfire.xcodeproj/project.pbxproj
+++ b/Bonfire.xcodeproj/project.pbxproj
@@ -12,6 +12,12 @@ objects = {
 24B1E4192B1ED1E200D9D1A8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 24B1E4242B1ED1E200D9D1A8 /* LaunchScreen.storyboard */; };
 24B1E41A2B1ED1E200D9D1A8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 24B1E4232B1ED1E200D9D1A8 /* Assets.xcassets */; };
 24B1E41B2B1ED1E200D9D1A8 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 24B1E4282B1ED1E200D9D1A8 /* Localizable.strings */; };
+9E6AA76793C74F82B8E410D7 /* DesignSystemColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCFAB9F89AF4057A7F3C9D6 /* DesignSystemColors.swift */; };
+3831F7C553634EBCB8E1A799 /* DesignSystemTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727108EB6FE4230A8AD675D /* DesignSystemTypography.swift */; };
+F76697C4C2204146A85D8DBC /* DesignSystemSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D4D020C8C3462C8D290ACA /* DesignSystemSpacing.swift */; };
+41B49056DF10409DA3EBFB0B /* DesignSystemCorners.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27E89ECE96D4BCB921D923D /* DesignSystemCorners.swift */; };
+6C9044C144E844FE804FA00F /* DesignSystemTextures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BB861349D224469A8F68B9E /* DesignSystemTextures.swift */; };
+CD1399DE866B4DE78DFD9FFE /* DesignSystemDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7985B135AE74DCFAF5788BC /* DesignSystemDemoView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -37,6 +43,12 @@ objects = {
 24B1E4392B1ED1E200D9D1A8 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 24B1E43A2B1ED1E200D9D1A8 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 24B1E43B2B1ED1E200D9D1A8 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
+2DCFAB9F89AF4057A7F3C9D6 /* DesignSystemColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemColors.swift; sourceTree = "<group>"; };
+A727108EB6FE4230A8AD675D /* DesignSystemTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemTypography.swift; sourceTree = "<group>"; };
+35D4D020C8C3462C8D290ACA /* DesignSystemSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemSpacing.swift; sourceTree = "<group>"; };
+E27E89ECE96D4BCB921D923D /* DesignSystemCorners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemCorners.swift; sourceTree = "<group>"; };
+1BB861349D224469A8F68B9E /* DesignSystemTextures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemTextures.swift; sourceTree = "<group>"; };
+D7985B135AE74DCFAF5788BC /* DesignSystemDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemDemoView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +108,11 @@ sourceTree = "<group>";
 24B1E4042B1ED1E200D9D1A8 /* DesignSystem */ = {
 isa = PBXGroup;
 children = (
+2DCFAB9F89AF4057A7F3C9D6 /* DesignSystemColors.swift */,
+A727108EB6FE4230A8AD675D /* DesignSystemTypography.swift */,
+35D4D020C8C3462C8D290ACA /* DesignSystemSpacing.swift */,
+E27E89ECE96D4BCB921D923D /* DesignSystemCorners.swift */,
+1BB861349D224469A8F68B9E /* DesignSystemTextures.swift */,
 24B1E4302B1ED1E200D9D1A8 /* .gitkeep */,
 );
 path = DesignSystem;
@@ -176,6 +193,7 @@ sourceTree = "<group>";
 24B1E40E2B1ED1E200D9D1A8 /* DevTools */ = {
 isa = PBXGroup;
 children = (
+D7985B135AE74DCFAF5788BC /* DesignSystemDemoView.swift */,
 24B1E43A2B1ED1E200D9D1A8 /* .gitkeep */,
 );
 path = DevTools;
@@ -276,6 +294,12 @@ runOnlyForDeploymentPostprocessing = 0;
 isa = PBXSourcesBuildPhase;
 buildActionMask = 2147483647;
 files = (
+9E6AA76793C74F82B8E410D7 /* DesignSystemColors.swift in Sources */,
+3831F7C553634EBCB8E1A799 /* DesignSystemTypography.swift in Sources */,
+F76697C4C2204146A85D8DBC /* DesignSystemSpacing.swift in Sources */,
+41B49056DF10409DA3EBFB0B /* DesignSystemCorners.swift in Sources */,
+6C9044C144E844FE804FA00F /* DesignSystemTextures.swift in Sources */,
+CD1399DE866B4DE78DFD9FFE /* DesignSystemDemoView.swift in Sources */,
 24B1E4182B1ED1E200D9D1A8 /* RootTabView.swift in Sources */,
 24B1E4172B1ED1E200D9D1A8 /* BonfireApp.swift in Sources */,
 );

--- a/Bonfire/Assets.xcassets/AgedParchment.colorset/Contents.json
+++ b/Bonfire/Assets.xcassets/AgedParchment.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.776",
+          "green" : "0.890",
+          "red" : "0.949"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Bonfire/Assets.xcassets/AmberGlow.colorset/Contents.json
+++ b/Bonfire/Assets.xcassets/AmberGlow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.278",
+          "green" : "0.702",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Bonfire/Assets.xcassets/AquaGlow.colorset/Contents.json
+++ b/Bonfire/Assets.xcassets/AquaGlow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.945",
+          "green" : "0.773",
+          "red" : "0.306"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Bonfire/Assets.xcassets/DeepWalnut.colorset/Contents.json
+++ b/Bonfire/Assets.xcassets/DeepWalnut.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.169",
+          "green" : "0.180",
+          "red" : "0.294"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Bonfire/Assets.xcassets/Ink.colorset/Contents.json
+++ b/Bonfire/Assets.xcassets/Ink.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.137",
+          "green" : "0.122",
+          "red" : "0.106"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Bonfire/DesignSystem/DesignSystemColors.swift
+++ b/Bonfire/DesignSystem/DesignSystemColors.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import UIKit
+
+/// Canonical color tokens for the Bonfire design system.
+/// These colors are inspired by a hearthstone palette with
+/// rich woods, warm parchment, and luminous magical accents.
+enum DesignColor {
+    static let deepWalnut = Color("DeepWalnut")
+    static let agedParchment = Color("AgedParchment")
+    static let ink = Color("Ink")
+    static let aquaGlow = Color("AquaGlow")
+    static let amberGlow = Color("AmberGlow")
+
+    /// UIKit compatibility for the color palette.
+    enum UIKit {
+        static let deepWalnut = UIColor(named: "DeepWalnut")!
+        static let agedParchment = UIColor(named: "AgedParchment")!
+        static let ink = UIColor(named: "Ink")!
+        static let aquaGlow = UIColor(named: "AquaGlow")!
+        static let amberGlow = UIColor(named: "AmberGlow")!
+    }
+}

--- a/Bonfire/DesignSystem/DesignSystemCorners.swift
+++ b/Bonfire/DesignSystem/DesignSystemCorners.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+/// Corner radius tokens to give controls a crafted feel.
+enum DesignCornerRadius {
+    static let sharp: CGFloat = 0
+    static let soft: CGFloat = 8
+    static let pill: CGFloat = 999
+    static let card: CGFloat = 16
+}

--- a/Bonfire/DesignSystem/DesignSystemSpacing.swift
+++ b/Bonfire/DesignSystem/DesignSystemSpacing.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+/// Spacing tokens follow a modular scale for consistent rhythm.
+enum DesignSpacing {
+    static let none: CGFloat = 0
+    static let xs: CGFloat = 4
+    static let sm: CGFloat = 8
+    static let md: CGFloat = 12
+    static let lg: CGFloat = 16
+    static let xl: CGFloat = 24
+    static let xxl: CGFloat = 32
+}

--- a/Bonfire/DesignSystem/DesignSystemTextures.swift
+++ b/Bonfire/DesignSystem/DesignSystemTextures.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Texture tokens provide thematic backgrounds for surfaces.
+/// They attempt to load an asset by name and gracefully fall back to
+/// lightweight programmatic placeholders so binary textures can remain
+/// out of source control until final artwork ships.
+enum DesignTexture: String, CaseIterable, Identifiable {
+    case wood
+    case parchment
+
+    var id: String { rawValue }
+
+    /// Asset catalog name that designers can replace with production artwork.
+    var assetName: String {
+        switch self {
+        case .wood:
+            return "WoodTexturePlaceholder"
+        case .parchment:
+            return "ParchmentTexturePlaceholder"
+        }
+    }
+
+    /// Attempt to load an image from the asset catalog.
+    func image(bundle: Bundle? = nil) -> Image? {
+        #if canImport(UIKit)
+        if let uiImage = UIImage(named: assetName, in: bundle ?? .main, with: nil) {
+            return Image(uiImage: uiImage)
+        }
+        #endif
+        return nil
+    }
+
+    /// A reusable SwiftUI view that renders either the asset texture
+    /// or a procedurally generated placeholder.
+    @ViewBuilder
+    var preview: some View {
+        if let asset = image() {
+            asset
+                .resizable()
+                .renderingMode(.original)
+                .accessibilityLabel(Text(accessibilityLabel))
+        } else {
+            TextureFallback(style: self)
+                .accessibilityLabel(Text(accessibilityLabel))
+        }
+    }
+
+    var accessibilityLabel: String {
+        switch self {
+        case .wood:
+            return "Wood grain texture placeholder"
+        case .parchment:
+            return "Aged parchment texture placeholder"
+        }
+    }
+}
+
+private struct TextureFallback: View {
+    let style: DesignTexture
+
+    var body: some View {
+        switch style {
+        case .wood:
+            wood
+        case .parchment:
+            parchment
+        }
+    }
+
+    private var wood: some View {
+        ZStack {
+            LinearGradient(
+                gradient: Gradient(colors: [
+                    Color(red: 0.20, green: 0.12, blue: 0.07),
+                    Color(red: 0.26, green: 0.16, blue: 0.10),
+                    Color(red: 0.18, green: 0.10, blue: 0.05)
+                ]),
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .overlay(
+                LinearGradient(
+                    gradient: Gradient(stops: [
+                        .init(color: Color.black.opacity(0.35), location: 0.0),
+                        .init(color: Color.clear, location: 0.45),
+                        .init(color: Color.black.opacity(0.25), location: 1.0)
+                    ]),
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            GrainOverlay()
+        }
+    }
+
+    private var parchment: some View {
+        ZStack {
+            LinearGradient(
+                gradient: Gradient(colors: [
+                    Color(red: 0.95, green: 0.90, blue: 0.76),
+                    Color(red: 0.90, green: 0.84, blue: 0.70),
+                    Color(red: 0.97, green: 0.94, blue: 0.83)
+                ]),
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            SpeckleOverlay()
+        }
+    }
+}
+
+private struct GrainOverlay: View {
+    var body: some View {
+        GeometryReader { geometry in
+            let stripeWidth = max(geometry.size.width / 32, 2)
+            let stripeCount = max(Int(ceil(geometry.size.width / stripeWidth)), 1)
+            HStack(spacing: 0) {
+                ForEach(0..<stripeCount, id: \.self) { index in
+                    Color.white.opacity(index.isMultiple(of: 2) ? 0.08 : 0.02)
+                        .frame(width: stripeWidth)
+                }
+            }
+        }
+        .blendMode(.overlay)
+        .opacity(0.35)
+    }
+}
+
+private struct SpeckleOverlay: View {
+    var body: some View {
+        GeometryReader { geometry in
+            let columns = Int(ceil(geometry.size.width / 16))
+            let rows = Int(ceil(geometry.size.height / 16))
+            ZStack {
+                ForEach(0..<rows * columns, id: \.self) { index in
+                    let column = index % columns
+                    let row = index / columns
+                    Circle()
+                        .fill(Color.black.opacity(opacity(for: index)))
+                        .frame(width: 3, height: 3)
+                        .offset(
+                            x: CGFloat(column) * 16 + xOffset(for: index),
+                            y: CGFloat(row) * 16 + yOffset(for: index)
+                        )
+                }
+            }
+        }
+        .blendMode(.multiply)
+        .opacity(0.45)
+    }
+
+    private func opacity(for index: Int) -> Double {
+        0.02 + 0.04 * pseudoRandom(for: index, seed: 11)
+    }
+
+    private func xOffset(for index: Int) -> CGFloat {
+        CGFloat(pseudoRandom(for: index, seed: 23) * 8.0 - 4.0)
+    }
+
+    private func yOffset(for index: Int) -> CGFloat {
+        CGFloat(pseudoRandom(for: index, seed: 47) * 8.0 - 4.0)
+    }
+
+    private func pseudoRandom(for index: Int, seed: Int) -> Double {
+        var hasher = Hasher()
+        hasher.combine(index)
+        hasher.combine(seed)
+        let hash = hasher.finalize()
+        let unsigned = UInt64(bitPattern: Int64(hash))
+        return Double(unsigned % 10_000) / 10_000.0
+    }
+}

--- a/Bonfire/DesignSystem/DesignSystemTypography.swift
+++ b/Bonfire/DesignSystem/DesignSystemTypography.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import UIKit
+
+/// Font tokens tuned for Hearthstone-inspired typography.
+/// Headers lean into a serif display while body styles favor legibility.
+enum DesignTypography {
+    enum Display {
+        static let font = Font.system(.largeTitle, design: .serif).weight(.black)
+        static let uiFont = UIFont.designSystemSerif(textStyle: .largeTitle, weight: .black)
+    }
+
+    enum Title {
+        static let font = Font.system(.title, design: .serif).weight(.semibold)
+        static let uiFont = UIFont.designSystemSerif(textStyle: .title1, weight: .semibold)
+    }
+
+    enum Body {
+        /// SF Pro body text prioritises legibility and dynamic type.
+        static let font = Font.system(.body, design: .default)
+        static let uiFont = UIFont.preferredFont(forTextStyle: .body)
+    }
+
+    enum Caption {
+        static let font = Font.system(.caption, design: .default)
+        static let uiFont = UIFont.preferredFont(forTextStyle: .caption1)
+    }
+}
+
+private extension UIFont {
+    static func designSystemSerif(textStyle: UIFont.TextStyle, weight: UIFont.Weight) -> UIFont {
+        let baseDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: textStyle)
+        let serifDescriptor = baseDescriptor.withDesign(.serif) ?? baseDescriptor
+        let weightedDescriptor = serifDescriptor.addingAttributes([
+            UIFontDescriptor.AttributeName.traits: [UIFontDescriptor.TraitKey.weight: weight]
+        ])
+        return UIFont(descriptor: weightedDescriptor, size: 0)
+    }
+}

--- a/Bonfire/DevTools/DesignSystemDemoView.swift
+++ b/Bonfire/DevTools/DesignSystemDemoView.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+
+struct DesignSystemDemoView: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: DesignSpacing.xl) {
+                paletteSection
+                typographySection
+                spacingSection
+                cornerRadiusSection
+                textureSection
+            }
+            .padding(DesignSpacing.xl)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(DesignColor.deepWalnut.ignoresSafeArea())
+    }
+
+    private var paletteSection: some View {
+        VStack(alignment: .leading, spacing: DesignSpacing.md) {
+            sectionHeader("Color Palette")
+            paletteRow(name: "Deep Walnut", color: DesignColor.deepWalnut, description: "Primary background and elevated wood surfaces")
+            paletteRow(name: "Aged Parchment", color: DesignColor.agedParchment, description: "Content surfaces and cards")
+            paletteRow(name: "Ink", color: DesignColor.ink, description: "Primary text and high contrast accents")
+            paletteRow(name: "Aqua Glow", color: DesignColor.aquaGlow, description: "Magical highlights and actions")
+            paletteRow(name: "Amber Glow", color: DesignColor.amberGlow, description: "Secondary highlights and warnings")
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: DesignCornerRadius.card)
+                .fill(DesignColor.agedParchment)
+                .shadow(color: DesignColor.deepWalnut.opacity(0.35), radius: 12, x: 0, y: 8)
+        )
+    }
+
+    private func paletteRow(name: String, color: Color, description: String) -> some View {
+        HStack(alignment: .center, spacing: DesignSpacing.md) {
+            RoundedRectangle(cornerRadius: DesignCornerRadius.soft)
+                .fill(color)
+                .frame(width: 56, height: 56)
+                .overlay(
+                    RoundedRectangle(cornerRadius: DesignCornerRadius.soft)
+                        .stroke(DesignColor.ink.opacity(0.1), lineWidth: 1)
+                )
+            VStack(alignment: .leading, spacing: DesignSpacing.xs) {
+                Text(name)
+                    .font(DesignTypography.Title.font)
+                    .foregroundColor(DesignColor.ink)
+                Text(description)
+                    .font(DesignTypography.Body.font)
+                    .foregroundColor(DesignColor.ink.opacity(0.8))
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private var typographySection: some View {
+        VStack(alignment: .leading, spacing: DesignSpacing.md) {
+            sectionHeader("Typography")
+            VStack(alignment: .leading, spacing: DesignSpacing.sm) {
+                Text("Display – Hearth & Heroes")
+                    .font(DesignTypography.Display.font)
+                    .foregroundColor(DesignColor.amberGlow)
+                    .shadow(color: DesignColor.deepWalnut.opacity(0.6), radius: 4, x: 0, y: 2)
+                Text("Title – Tales of the Bonfire")
+                    .font(DesignTypography.Title.font)
+                    .foregroundColor(DesignColor.ink)
+                Text("Body – SF Pro keeps long-form reading comfortable and accessible across locales.")
+                    .font(DesignTypography.Body.font)
+                    .foregroundColor(DesignColor.ink)
+                Text("Caption – Quick notes, tooltips, and metadata.")
+                    .font(DesignTypography.Caption.font)
+                    .foregroundColor(DesignColor.ink.opacity(0.7))
+            }
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: DesignCornerRadius.card)
+                    .fill(DesignColor.agedParchment)
+            )
+        }
+    }
+
+    private var spacingSection: some View {
+        VStack(alignment: .leading, spacing: DesignSpacing.md) {
+            sectionHeader("Spacing Scale")
+            HStack(spacing: DesignSpacing.lg) {
+                spacingSample(label: "XS", value: DesignSpacing.xs)
+                spacingSample(label: "SM", value: DesignSpacing.sm)
+                spacingSample(label: "MD", value: DesignSpacing.md)
+                spacingSample(label: "LG", value: DesignSpacing.lg)
+                spacingSample(label: "XL", value: DesignSpacing.xl)
+                spacingSample(label: "XXL", value: DesignSpacing.xxl)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: DesignCornerRadius.card)
+                    .fill(DesignColor.agedParchment)
+            )
+        }
+    }
+
+    private func spacingSample(label: String, value: CGFloat) -> some View {
+        VStack(spacing: DesignSpacing.xs) {
+            Text(label)
+                .font(DesignTypography.Caption.font)
+                .foregroundColor(DesignColor.ink)
+            RoundedRectangle(cornerRadius: DesignCornerRadius.soft)
+                .fill(DesignColor.aquaGlow.opacity(0.6))
+                .frame(width: max(value * 2, DesignSpacing.lg), height: DesignSpacing.sm)
+            Text("\(Int(value)) pt")
+                .font(DesignTypography.Caption.font)
+                .foregroundColor(DesignColor.ink.opacity(0.7))
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var cornerRadiusSection: some View {
+        VStack(alignment: .leading, spacing: DesignSpacing.md) {
+            sectionHeader("Corner Radius Tokens")
+            HStack(spacing: DesignSpacing.lg) {
+                cornerSample(name: "Sharp", radius: DesignCornerRadius.sharp)
+                cornerSample(name: "Soft", radius: DesignCornerRadius.soft)
+                cornerSample(name: "Card", radius: DesignCornerRadius.card)
+                cornerSample(name: "Pill", radius: DesignCornerRadius.pill, isPill: true)
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: DesignCornerRadius.card)
+                .fill(DesignColor.agedParchment)
+        )
+    }
+
+    private func cornerSample(name: String, radius: CGFloat, isPill: Bool = false) -> some View {
+        VStack(spacing: DesignSpacing.sm) {
+            RoundedRectangle(cornerRadius: isPill ? DesignCornerRadius.pill : radius)
+                .fill(DesignColor.amberGlow.opacity(0.8))
+                .frame(width: isPill ? 88 : 60, height: isPill ? 32 : 60)
+                .overlay(
+                    RoundedRectangle(cornerRadius: isPill ? DesignCornerRadius.pill : radius)
+                        .stroke(DesignColor.ink.opacity(0.15), lineWidth: 1)
+                )
+            Text(name)
+                .font(DesignTypography.Caption.font)
+                .foregroundColor(DesignColor.ink)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var textureSection: some View {
+        VStack(alignment: .leading, spacing: DesignSpacing.md) {
+            sectionHeader("Texture Placeholders")
+            ForEach(DesignTexture.allCases) { texture in
+                VStack(alignment: .leading, spacing: DesignSpacing.sm) {
+                    Text(texture.rawValue.capitalized)
+                        .font(DesignTypography.Title.font)
+                        .foregroundColor(DesignColor.ink)
+                    texture.preview
+                        .scaledToFill()
+                        .frame(height: 80)
+                        .clipShape(RoundedRectangle(cornerRadius: DesignCornerRadius.card))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: DesignCornerRadius.card)
+                                .stroke(DesignColor.ink.opacity(0.1), lineWidth: 1)
+                        )
+                }
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: DesignCornerRadius.card)
+                .fill(DesignColor.agedParchment)
+        )
+    }
+
+    private func sectionHeader(_ title: LocalizedStringKey) -> some View {
+        Text(title)
+            .font(DesignTypography.Title.font)
+            .foregroundColor(DesignColor.amberGlow)
+            .padding(.bottom, DesignSpacing.sm)
+    }
+}
+
+struct DesignSystemDemoView_Previews: PreviewProvider {
+    static var previews: some View {
+        DesignSystemDemoView()
+            .environment(\.colorScheme, .dark)
+    }
+}


### PR DESCRIPTION
## Summary
- replace texture tokens with an asset-aware API that falls back to procedural SwiftUI placeholders
- update the design system demo to use the new preview rendering and clarify palette copy
- ignore generated binary asset outputs and remove temporary texture PNGs from source control

## Testing
- not run (iOS build tooling unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68db91d64d948331995d36dae02e2504