### PR TITLE
Add content models and bundle Little River Lantern story

### DIFF
--- a/Bonfire.xcodeproj/project.pbxproj
+++ b/Bonfire.xcodeproj/project.pbxproj
@@ -19,6 +19,11 @@ F76697C4C2204146A85D8DBC /* DesignSystemSpacing.swift in Sources */ = {isa = PBX
 6C9044C144E844FE804FA00F /* DesignSystemTextures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BB861349D224469A8F68B9E /* DesignSystemTextures.swift */; };
 CD1399DE866B4DE78DFD9FFE /* DesignSystemDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7985B135AE74DCFAF5788BC /* DesignSystemDemoView.swift */; };
 A1E95B6B65A544A2B5B0D4F1 /* DesignSystemVisualShells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D53F3158A1B4C73A4E4F4BA /* DesignSystemVisualShells.swift */; };
+E4F1A2B93F524B6F8D5E2D6A /* ReaderHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F1A2B83F524B6F8D5E2D6A /* ReaderHomeView.swift */; };
+E4F1A2BB3F524B6F8D5E2D6A /* ReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F1A2BA3F524B6F8D5E2D6A /* ReaderView.swift */; };
+E4F1A2BD3F524B6F8D5E2D6A /* ContentModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F1A2BC3F524B6F8D5E2D6A /* ContentModels.swift */; };
+E4F1A2BF3F524B6F8D5E2D6A /* ContentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F1A2BE3F524B6F8D5E2D6A /* ContentProvider.swift */; };
+E4F1A2C13F524B6F8D5E2D6A /* the_little_river_lantern.json in Resources */ = {isa = PBXBuildFile; fileRef = E4F1A2C03F524B6F8D5E2D6A /* the_little_river_lantern.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,6 +56,11 @@ E27E89ECE96D4BCB921D923D /* DesignSystemCorners.swift */ = {isa = PBXFileReferen
 1BB861349D224469A8F68B9E /* DesignSystemTextures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemTextures.swift; sourceTree = "<group>"; };
 D7985B135AE74DCFAF5788BC /* DesignSystemDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemDemoView.swift; sourceTree = "<group>"; };
 4D53F3158A1B4C73A4E4F4BA /* DesignSystemVisualShells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Components/DesignSystemVisualShells.swift; sourceTree = "<group>"; };
+E4F1A2B83F524B6F8D5E2D6A /* ReaderHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderHomeView.swift; sourceTree = "<group>"; };
+E4F1A2BA3F524B6F8D5E2D6A /* ReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderView.swift; sourceTree = "<group>"; };
+E4F1A2BC3F524B6F8D5E2D6A /* ContentModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/ContentModels.swift; sourceTree = "<group>"; };
+E4F1A2BE3F524B6F8D5E2D6A /* ContentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Content/ContentProvider.swift; sourceTree = "<group>"; };
+E4F1A2C03F524B6F8D5E2D6A /* the_little_river_lantern.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Content/the_little_river_lantern.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -129,9 +139,30 @@ children = (
 path = Components;
 sourceTree = "<group>";
 };
+E4F1A2C23F524B6F8D5E2D6A /* Models */ = {
+    isa = PBXGroup;
+    children = (
+        E4F1A2BC3F524B6F8D5E2D6A /* ContentModels.swift */,
+    );
+    path = Models;
+    sourceTree = "<group>";
+};
+E4F1A2C33F524B6F8D5E2D6A /* Content */ = {
+    isa = PBXGroup;
+    children = (
+        E4F1A2BE3F524B6F8D5E2D6A /* ContentProvider.swift */,
+        E4F1A2C03F524B6F8D5E2D6A /* the_little_river_lantern.json */,
+    );
+    path = Content;
+    sourceTree = "<group>";
+};
 24B1E4052B1ED1E200D9D1A8 /* Reader */ = {
 isa = PBXGroup;
 children = (
+E4F1A2B83F524B6F8D5E2D6A /* ReaderHomeView.swift */,
+E4F1A2BA3F524B6F8D5E2D6A /* ReaderView.swift */,
+E4F1A2C23F524B6F8D5E2D6A /* Models */,
+E4F1A2C33F524B6F8D5E2D6A /* Content */,
 24B1E4312B1ED1E200D9D1A8 /* .gitkeep */,
 );
 path = Reader;
@@ -295,6 +326,7 @@ files = (
 24B1E4192B1ED1E200D9D1A8 /* LaunchScreen.storyboard in Resources */,
 24B1E41A2B1ED1E200D9D1A8 /* Assets.xcassets in Resources */,
 24B1E41B2B1ED1E200D9D1A8 /* Localizable.strings in Resources */,
+E4F1A2C13F524B6F8D5E2D6A /* the_little_river_lantern.json in Resources */,
 );
 runOnlyForDeploymentPostprocessing = 0;
 };
@@ -312,6 +344,10 @@ F76697C4C2204146A85D8DBC /* DesignSystemSpacing.swift in Sources */,
 6C9044C144E844FE804FA00F /* DesignSystemTextures.swift in Sources */,
 CD1399DE866B4DE78DFD9FFE /* DesignSystemDemoView.swift in Sources */,
 A1E95B6B65A544A2B5B0D4F1 /* DesignSystemVisualShells.swift in Sources */,
+E4F1A2B93F524B6F8D5E2D6A /* ReaderHomeView.swift in Sources */,
+E4F1A2BB3F524B6F8D5E2D6A /* ReaderView.swift in Sources */,
+E4F1A2BD3F524B6F8D5E2D6A /* ContentModels.swift in Sources */,
+E4F1A2BF3F524B6F8D5E2D6A /* ContentProvider.swift in Sources */,
 24B1E4182B1ED1E200D9D1A8 /* RootTabView.swift in Sources */,
 24B1E4172B1ED1E200D9D1A8 /* BonfireApp.swift in Sources */,
 );

--- a/Bonfire/Reader/Content/ContentProvider.swift
+++ b/Bonfire/Reader/Content/ContentProvider.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+private struct Library: Codable {
+    let books: [Book]
+}
+
+final class ContentProvider {
+    static let shared = ContentProvider()
+
+    private(set) var books: [Book] = []
+
+    private let bundle: Bundle
+
+    init(bundle: Bundle = .main) {
+        self.bundle = bundle
+        self.books = loadBooks()
+    }
+
+    private func loadBooks() -> [Book] {
+        guard let url = bundle.url(forResource: "the_little_river_lantern", withExtension: "json") else {
+            assertionFailure("Missing bundled story resource.")
+            return []
+        }
+
+        do {
+            let data = try Data(contentsOf: url)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let library = try decoder.decode(Library.self, from: data)
+            return library.books
+        } catch {
+            assertionFailure("Failed to decode bundled content: \(error)")
+            return []
+        }
+    }
+
+    func book(withID id: Book.ID) -> Book? {
+        books.first { $0.id == id }
+    }
+}

--- a/Bonfire/Reader/Content/the_little_river_lantern.json
+++ b/Bonfire/Reader/Content/the_little_river_lantern.json
@@ -1,0 +1,178 @@
+{
+  "books": [
+    {
+      "id": "9c6a3618-5d7c-4f9c-b7c1-622c317346c1",
+      "title": "The Little River Lantern",
+      "subtitle": "A Moonlit Story",
+      "author": "Bonfire Studios",
+      "summary": "Mai crafts a special lantern to guide her father home during the river festival.",
+      "level": "A1",
+      "topic": "adventure",
+      "length": "short",
+      "pages": [
+        {
+          "index": 1,
+          "variants": [
+            {
+              "id": "page-1-original",
+              "kind": "original",
+              "languageCode": "en",
+              "content": "Mai lived in a small riverside town. Every month the people lit lanterns to thank the gentle river."
+            },
+            {
+              "id": "page-1-translation",
+              "kind": "translation",
+              "languageCode": "vi",
+              "content": "Mai sống trong một thị trấn nhỏ bên sông. Mỗi tháng mọi người thắp đèn lồng để cảm ơn dòng sông hiền hòa."
+            }
+          ],
+          "dictionaryEntries": [
+            {
+              "term": "lantern",
+              "definition": "a light inside a protective case with handles",
+              "partOfSpeech": "noun",
+              "example": "Mai held the lantern carefully.",
+              "level": "A1"
+            },
+            {
+              "term": "gentle",
+              "definition": "kind and calm in nature",
+              "partOfSpeech": "adjective",
+              "example": "The gentle river moved slowly.",
+              "level": "A1"
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "variants": [
+            {
+              "id": "page-2-original",
+              "kind": "original",
+              "languageCode": "en",
+              "content": "Her father was a fisherman. On the festival night he rowed home late, searching for their house among the glowing lights."
+            },
+            {
+              "id": "page-2-translation",
+              "kind": "translation",
+              "languageCode": "vi",
+              "content": "Cha của Mai là một người đánh cá. Đêm lễ hội ông chèo thuyền về muộn, tìm nhà họ giữa những ánh đèn sáng."
+            }
+          ],
+          "dictionaryEntries": [
+            {
+              "term": "festival",
+              "definition": "a day of celebration",
+              "partOfSpeech": "noun",
+              "example": "The lantern festival filled the town with music.",
+              "level": "A1"
+            },
+            {
+              "term": "glowing",
+              "definition": "shining with a soft light",
+              "partOfSpeech": "adjective",
+              "example": "Glowing lights danced on the river.",
+              "level": "A1"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "variants": [
+            {
+              "id": "page-3-original",
+              "kind": "original",
+              "languageCode": "en",
+              "content": "Mai wanted to help. She built a small lantern shaped like a lotus flower and hung it by the water."
+            },
+            {
+              "id": "page-3-translation",
+              "kind": "translation",
+              "languageCode": "vi",
+              "content": "Mai muốn giúp đỡ. Cô làm một chiếc đèn lồng nhỏ hình hoa sen và treo nó bên mặt nước."
+            }
+          ],
+          "dictionaryEntries": [
+            {
+              "term": "lotus",
+              "definition": "a water plant with large pink or white flowers",
+              "partOfSpeech": "noun",
+              "example": "The lantern looked like a pink lotus.",
+              "level": "A1"
+            },
+            {
+              "term": "hung",
+              "definition": "to attach something so it swings or stays in the air",
+              "partOfSpeech": "verb",
+              "example": "She hung the lantern by the water.",
+              "level": "A1"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "variants": [
+            {
+              "id": "page-4-original",
+              "kind": "original",
+              "languageCode": "en",
+              "content": "When her father saw the lotus lantern, he smiled. The soft light led him straight home, and Mai felt proud."
+            },
+            {
+              "id": "page-4-translation",
+              "kind": "translation",
+              "languageCode": "vi",
+              "content": "Khi cha thấy chiếc đèn lồng hình hoa sen, ông mỉm cười. Ánh sáng dịu dàng dẫn ông về thẳng nhà, và Mai cảm thấy tự hào."
+            }
+          ],
+          "dictionaryEntries": [
+            {
+              "term": "proud",
+              "definition": "happy because of something you or someone close has done",
+              "partOfSpeech": "adjective",
+              "example": "Mai felt proud of her lantern.",
+              "level": "A1"
+            },
+            {
+              "term": "soft",
+              "definition": "pleasantly gentle and not harsh",
+              "partOfSpeech": "adjective",
+              "example": "The soft light warmed the night.",
+              "level": "A1"
+            }
+          ]
+        }
+      ],
+      "dictionary": [
+        {
+          "term": "lantern",
+          "definition": "a light inside a protective case with handles",
+          "partOfSpeech": "noun",
+          "example": "Mai held the lantern carefully.",
+          "level": "A1"
+        },
+        {
+          "term": "festival",
+          "definition": "a day of celebration",
+          "partOfSpeech": "noun",
+          "example": "The lantern festival filled the town with music.",
+          "level": "A1"
+        },
+        {
+          "term": "lotus",
+          "definition": "a water plant with large pink or white flowers",
+          "partOfSpeech": "noun",
+          "example": "The lantern looked like a pink lotus.",
+          "level": "A1"
+        },
+        {
+          "term": "proud",
+          "definition": "happy because of something you or someone close has done",
+          "partOfSpeech": "adjective",
+          "example": "Mai felt proud of her lantern.",
+          "level": "A1"
+        }
+      ]
+    }
+  ]
+}

--- a/Bonfire/Reader/Models/ContentModels.swift
+++ b/Bonfire/Reader/Models/ContentModels.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+enum Level: String, Codable, CaseIterable, Identifiable {
+    case a1 = "A1"
+    case a2 = "A2"
+    case b1 = "B1"
+    case b2 = "B2"
+
+    var id: String { rawValue }
+}
+
+enum BookTopic: String, Codable, CaseIterable, Identifiable {
+    case adventure
+    case science
+    case culture
+    case fantasy
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .adventure:
+            return "Adventure"
+        case .science:
+            return "Science"
+        case .culture:
+            return "Culture"
+        case .fantasy:
+            return "Fantasy"
+        }
+    }
+}
+
+enum BookLength: String, Codable, CaseIterable, Identifiable {
+    case short
+    case medium
+    case long
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .short:
+            return "Short"
+        case .medium:
+            return "Medium"
+        case .long:
+            return "Long"
+        }
+    }
+}
+
+struct TextVariant: Codable, Identifiable, Hashable {
+    enum Kind: String, Codable {
+        case original
+        case translation
+        case phonetic
+    }
+
+    let id: String
+    let kind: Kind
+    let languageCode: String
+    let content: String
+
+    init(id: String = UUID().uuidString, kind: Kind, languageCode: String, content: String) {
+        self.id = id
+        self.kind = kind
+        self.languageCode = languageCode
+        self.content = content
+    }
+}
+
+extension TextVariant.Kind {
+    var displayName: String {
+        switch self {
+        case .original:
+            return "Original"
+        case .translation:
+            return "Translation"
+        case .phonetic:
+            return "Pronunciation"
+        }
+    }
+}
+
+struct DictionaryEntry: Codable, Identifiable, Hashable {
+    let term: String
+    let definition: String
+    let partOfSpeech: String
+    let example: String
+    let level: Level
+
+    var id: String { term }
+}
+
+struct Page: Codable, Identifiable, Hashable {
+    let index: Int
+    let variants: [TextVariant]
+    let dictionaryEntries: [DictionaryEntry]
+
+    var id: Int { index }
+
+    var primaryText: String {
+        if let original = variants.first(where: { $0.kind == .original }) {
+            return original.content
+        }
+        return variants.first?.content ?? ""
+    }
+}
+
+struct Book: Codable, Identifiable, Hashable {
+    let id: UUID
+    let title: String
+    let subtitle: String?
+    let author: String
+    let summary: String
+    let level: Level
+    let topic: BookTopic
+    let length: BookLength
+    let pages: [Page]
+    let dictionary: [DictionaryEntry]
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        subtitle: String? = nil,
+        author: String,
+        summary: String,
+        level: Level,
+        topic: BookTopic,
+        length: BookLength,
+        pages: [Page],
+        dictionary: [DictionaryEntry]
+    ) {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.author = author
+        self.summary = summary
+        self.level = level
+        self.topic = topic
+        self.length = length
+        self.pages = pages
+        self.dictionary = dictionary
+    }
+
+    var tags: [String] {
+        [level.rawValue, topic.title, length.title]
+    }
+}
+
+struct ReadingSession: Codable, Identifiable, Hashable {
+    let id: UUID
+    let bookID: Book.ID
+    let startedAt: Date
+    let duration: TimeInterval
+    let completedPageIndices: [Int]
+
+    init(
+        id: UUID = UUID(),
+        bookID: Book.ID,
+        startedAt: Date,
+        duration: TimeInterval,
+        completedPageIndices: [Int] = []
+    ) {
+        self.id = id
+        self.bookID = bookID
+        self.startedAt = startedAt
+        self.duration = duration
+        self.completedPageIndices = completedPageIndices
+    }
+}
+
+struct WordProgress: Codable, Identifiable, Hashable {
+    let id: UUID
+    let term: String
+    var encounters: Int
+    var mastery: Double
+    var lastReviewed: Date?
+
+    init(id: UUID = UUID(), term: String, encounters: Int = 0, mastery: Double = 0, lastReviewed: Date? = nil) {
+        self.id = id
+        self.term = term
+        self.encounters = encounters
+        self.mastery = mastery
+        self.lastReviewed = lastReviewed
+    }
+}
+
+struct BookProgress: Codable, Identifiable, Hashable {
+    let id: UUID
+    let bookID: Book.ID
+    var currentPageIndex: Int
+    var isCompleted: Bool
+    var wordProgress: [WordProgress]
+    var lastReadAt: Date?
+
+    init(
+        id: UUID = UUID(),
+        bookID: Book.ID,
+        currentPageIndex: Int = 0,
+        isCompleted: Bool = false,
+        wordProgress: [WordProgress] = [],
+        lastReadAt: Date? = nil
+    ) {
+        self.id = id
+        self.bookID = bookID
+        self.currentPageIndex = currentPageIndex
+        self.isCompleted = isCompleted
+        self.wordProgress = wordProgress
+        self.lastReadAt = lastReadAt
+    }
+}


### PR DESCRIPTION
## Summary
- define reader content and progress models for levels, pages, and progress tracking
- bundle the “The Little River Lantern” sample story and load it through an in-memory content provider
- update the reader home experience to surface the bundled book and show paginated page content

## Testing
- Not run (iOS build tooling is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68db9cf8ccac833180aaaece5781a822