### PR TITLE
Add animated difficulty gear slider design

### DIFF
--- a/Bonfire/DevTools/DesignSystemDemoView.swift
+++ b/Bonfire/DevTools/DesignSystemDemoView.swift
@@ -236,6 +236,13 @@ struct DesignSystemDemoView: View {
                 }
 
                 VStack(alignment: .leading, spacing: DesignSpacing.md) {
+                    Text("Difficulty Gear Slider")
+                        .font(DesignTypography.Title.font)
+                        .foregroundColor(DesignColor.amberGlow)
+                    DifficultyGearSlider()
+                }
+
+                VStack(alignment: .leading, spacing: DesignSpacing.md) {
                     Text("Star Particles")
                         .font(DesignTypography.Title.font)
                         .foregroundColor(DesignColor.amberGlow)


### PR DESCRIPTION
## Summary
- create a vertical DifficultyGearSlider component with four labeled stops and an animated gear knob
- expose a preview and surface the new slider within the design system demo screen

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dbdcfaac3c8331be3cea2366d081a2