### PR TITLE
Add reader translation popover and vocabulary storage

### DIFF
--- a/Bonfire/Dictionary/WordTranslation.swift
+++ b/Bonfire/Dictionary/WordTranslation.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+enum WordPartOfSpeech: String, Codable, CaseIterable {
+    case noun
+    case verb
+    case adjective
+    case adverb
+    case pronoun
+    case preposition
+    case conjunction
+    case article
+    case determiner
+    case phrase
+    case expression
+    case properNoun = "proper_noun"
+    case unknown
+
+    init(label: String) {
+        let normalized = label.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch normalized {
+        case "noun":
+            self = .noun
+        case "verb":
+            self = .verb
+        case "adjective":
+            self = .adjective
+        case "adverb":
+            self = .adverb
+        case "pronoun":
+            self = .pronoun
+        case "preposition":
+            self = .preposition
+        case "conjunction":
+            self = .conjunction
+        case "article":
+            self = .article
+        case "determiner":
+            self = .determiner
+        case "phrase":
+            self = .phrase
+        case "expression":
+            self = .expression
+        case "proper noun", "proper_noun":
+            self = .properNoun
+        default:
+            self = .unknown
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .properNoun:
+            return "Proper noun"
+        case .unknown:
+            return "Unknown"
+        default:
+            return rawValue.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+    }
+}
+
+struct WordTranslation: Equatable {
+    let headword: String
+    let normalized: String
+    let vietnamese: String
+    let partOfSpeech: WordPartOfSpeech
+    let englishDefinition: String?
+}

--- a/Bonfire/Dictionary/WordTranslationProvider.swift
+++ b/Bonfire/Dictionary/WordTranslationProvider.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+final class WordTranslationProvider {
+    struct LexiconEntry {
+        let translation: String
+        let partOfSpeech: WordPartOfSpeech
+    }
+
+    static let shared = WordTranslationProvider()
+
+    private let lexicon: [String: LexiconEntry]
+
+    init() {
+        lexicon = [
+            "a": LexiconEntry(translation: "một", partOfSpeech: .article),
+            "among": LexiconEntry(translation: "giữa", partOfSpeech: .preposition),
+            "and": LexiconEntry(translation: "và", partOfSpeech: .conjunction),
+            "built": LexiconEntry(translation: "xây dựng", partOfSpeech: .verb),
+            "by": LexiconEntry(translation: "bởi", partOfSpeech: .preposition),
+            "every": LexiconEntry(translation: "mỗi", partOfSpeech: .determiner),
+            "father": LexiconEntry(translation: "cha", partOfSpeech: .noun),
+            "felt": LexiconEntry(translation: "cảm thấy", partOfSpeech: .verb),
+            "festival": LexiconEntry(translation: "lễ hội", partOfSpeech: .noun),
+            "fisherman": LexiconEntry(translation: "ngư dân", partOfSpeech: .noun),
+            "flower": LexiconEntry(translation: "bông hoa", partOfSpeech: .noun),
+            "for": LexiconEntry(translation: "cho", partOfSpeech: .preposition),
+            "gentle": LexiconEntry(translation: "hiền hòa", partOfSpeech: .adjective),
+            "glowing": LexiconEntry(translation: "sáng rực", partOfSpeech: .adjective),
+            "he": LexiconEntry(translation: "ông ấy", partOfSpeech: .pronoun),
+            "help": LexiconEntry(translation: "giúp đỡ", partOfSpeech: .verb),
+            "her": LexiconEntry(translation: "của cô ấy", partOfSpeech: .pronoun),
+            "him": LexiconEntry(translation: "ông ấy", partOfSpeech: .pronoun),
+            "home": LexiconEntry(translation: "nhà", partOfSpeech: .noun),
+            "house": LexiconEntry(translation: "ngôi nhà", partOfSpeech: .noun),
+            "hung": LexiconEntry(translation: "treo", partOfSpeech: .verb),
+            "in": LexiconEntry(translation: "trong", partOfSpeech: .preposition),
+            "it": LexiconEntry(translation: "nó", partOfSpeech: .pronoun),
+            "lantern": LexiconEntry(translation: "đèn lồng", partOfSpeech: .noun),
+            "lanterns": LexiconEntry(translation: "những chiếc đèn lồng", partOfSpeech: .noun),
+            "late": LexiconEntry(translation: "muộn", partOfSpeech: .adverb),
+            "led": LexiconEntry(translation: "dẫn đường", partOfSpeech: .verb),
+            "light": LexiconEntry(translation: "ánh sáng", partOfSpeech: .noun),
+            "lights": LexiconEntry(translation: "những ánh đèn", partOfSpeech: .noun),
+            "like": LexiconEntry(translation: "như", partOfSpeech: .preposition),
+            "lit": LexiconEntry(translation: "thắp sáng", partOfSpeech: .verb),
+            "lived": LexiconEntry(translation: "sống", partOfSpeech: .verb),
+            "lotus": LexiconEntry(translation: "hoa sen", partOfSpeech: .noun),
+            "mai": LexiconEntry(translation: "Mai", partOfSpeech: .properNoun),
+            "month": LexiconEntry(translation: "tháng", partOfSpeech: .noun),
+            "night": LexiconEntry(translation: "đêm", partOfSpeech: .noun),
+            "on": LexiconEntry(translation: "trên", partOfSpeech: .preposition),
+            "people": LexiconEntry(translation: "mọi người", partOfSpeech: .noun),
+            "proud": LexiconEntry(translation: "tự hào", partOfSpeech: .adjective),
+            "river": LexiconEntry(translation: "dòng sông", partOfSpeech: .noun),
+            "riverside": LexiconEntry(translation: "ven sông", partOfSpeech: .adjective),
+            "rowed": LexiconEntry(translation: "chèo thuyền", partOfSpeech: .verb),
+            "saw": LexiconEntry(translation: "nhìn thấy", partOfSpeech: .verb),
+            "searching": LexiconEntry(translation: "tìm kiếm", partOfSpeech: .verb),
+            "shaped": LexiconEntry(translation: "có hình dạng", partOfSpeech: .adjective),
+            "she": LexiconEntry(translation: "cô ấy", partOfSpeech: .pronoun),
+            "small": LexiconEntry(translation: "nhỏ bé", partOfSpeech: .adjective),
+            "smiled": LexiconEntry(translation: "mỉm cười", partOfSpeech: .verb),
+            "soft": LexiconEntry(translation: "êm dịu", partOfSpeech: .adjective),
+            "straight": LexiconEntry(translation: "thẳng tắp", partOfSpeech: .adverb),
+            "thank": LexiconEntry(translation: "cảm ơn", partOfSpeech: .verb),
+            "the": LexiconEntry(translation: "(mạo từ xác định)", partOfSpeech: .article),
+            "their": LexiconEntry(translation: "của họ", partOfSpeech: .determiner),
+            "to": LexiconEntry(translation: "để", partOfSpeech: .preposition),
+            "town": LexiconEntry(translation: "thị trấn", partOfSpeech: .noun),
+            "wanted": LexiconEntry(translation: "muốn", partOfSpeech: .verb),
+            "was": LexiconEntry(translation: "là", partOfSpeech: .verb),
+            "water": LexiconEntry(translation: "nước", partOfSpeech: .noun),
+            "when": LexiconEntry(translation: "khi", partOfSpeech: .conjunction)
+        ]
+    }
+
+    func translation(for selection: WordDetectingTextView.WordSelection, in book: Book) -> WordTranslation {
+        let normalized = selection.normalized
+        let dictionaryEntry = book.dictionary.first { $0.term.lowercased() == normalized }
+        let lexiconEntry = lexicon[normalized]
+        let partOfSpeech: WordPartOfSpeech
+        if let lexiconEntry {
+            partOfSpeech = lexiconEntry.partOfSpeech
+        } else if let dictionaryEntry {
+            partOfSpeech = WordPartOfSpeech(label: dictionaryEntry.partOfSpeech)
+        } else {
+            partOfSpeech = .unknown
+        }
+
+        let translation = lexiconEntry?.translation ?? selection.original
+        let headword = dictionaryEntry?.term ?? selection.original
+        let englishDefinition = dictionaryEntry?.definition
+
+        return WordTranslation(
+            headword: headword,
+            normalized: normalized,
+            vietnamese: translation,
+            partOfSpeech: partOfSpeech,
+            englishDefinition: englishDefinition
+        )
+    }
+}

--- a/Bonfire/Storage/VocabularyStore.swift
+++ b/Bonfire/Storage/VocabularyStore.swift
@@ -1,0 +1,108 @@
+import Combine
+import Foundation
+
+struct VocabularyEntry: Identifiable, Codable, Equatable {
+    let id: UUID
+    let original: String
+    let normalized: String
+    let translation: String
+    let partOfSpeech: WordPartOfSpeech
+    let englishDefinition: String?
+    let sampleSentence: String
+    let bookID: UUID
+    let pageIndex: Int
+    let dateAdded: Date
+
+    init(
+        id: UUID = UUID(),
+        original: String,
+        normalized: String,
+        translation: String,
+        partOfSpeech: WordPartOfSpeech,
+        englishDefinition: String?,
+        sampleSentence: String,
+        bookID: UUID,
+        pageIndex: Int,
+        dateAdded: Date = Date()
+    ) {
+        self.id = id
+        self.original = original
+        self.normalized = normalized
+        self.translation = translation
+        self.partOfSpeech = partOfSpeech
+        self.englishDefinition = englishDefinition
+        self.sampleSentence = sampleSentence
+        self.bookID = bookID
+        self.pageIndex = pageIndex
+        self.dateAdded = dateAdded
+    }
+}
+
+final class VocabularyStore: ObservableObject {
+    static let shared = VocabularyStore()
+
+    @Published private(set) var entries: [VocabularyEntry]
+
+    private let storageKey = "vocabulary.entries"
+    private let userDefaults: UserDefaults
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+
+        if let data = userDefaults.data(forKey: storageKey),
+           let decoded = try? decoder.decode([VocabularyEntry].self, from: data) {
+            entries = decoded
+        } else {
+            entries = []
+        }
+    }
+
+    @discardableResult
+    func addWord(
+        original: String,
+        translation: WordTranslation,
+        sampleSentence: String,
+        bookID: UUID,
+        pageIndex: Int
+    ) -> VocabularyEntry {
+        let normalized = translation.normalized
+        let entry = VocabularyEntry(
+            id: existingEntry(withNormalized: normalized)?.id ?? UUID(),
+            original: original,
+            normalized: normalized,
+            translation: translation.vietnamese,
+            partOfSpeech: translation.partOfSpeech,
+            englishDefinition: translation.englishDefinition,
+            sampleSentence: sampleSentence,
+            bookID: bookID,
+            pageIndex: pageIndex,
+            dateAdded: Date()
+        )
+
+        if let index = entries.firstIndex(where: { $0.normalized == normalized }) {
+            entries[index] = entry
+        } else {
+            entries.append(entry)
+        }
+
+        persist()
+        return entry
+    }
+
+    private func existingEntry(withNormalized normalized: String) -> VocabularyEntry? {
+        entries.first { $0.normalized == normalized }
+    }
+
+    private func persist() {
+        do {
+            let data = try encoder.encode(entries)
+            userDefaults.set(data, forKey: storageKey)
+        } catch {
+            print("Failed to persist vocabulary: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a translation lexicon and shared vocabulary store for the reader experience
- surface a contextual popover on word taps that shows the Vietnamese meaning, part of speech, and lets readers add the word
- support double-tap saving with sample sentence capture and analytics logging

## Testing
- not run (iOS build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbf2c95db083319081113661fbc110