### PR TITLE
Add CloudKit content schema and development seed

### DIFF
--- a/Bonfire.xcodeproj/project.pbxproj
+++ b/Bonfire.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@ C45972F654074A77A45AF701 /* AchievementsViewModel.swift in Sources */ = {isa = P
 2C4DC2F177CD4951B7280C22 /* AchievementPatchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CC2E13C7EC4966B23E70E1 /* AchievementPatchView.swift */; };
 AB13F528B34449AC8CA83C9F /* ReaderRecordingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7824C8A609A54ABF8F32298F /* ReaderRecordingStore.swift */; };
 195983EEC1AA45BAA195F2A9 /* VocabularyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF18ABF9DF94A16B0C71C18 /* VocabularyStore.swift */; };
+E5F0C8A7A9E44929B0CF8F6D /* CloudContentRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C8F2F4A3B3F493A8E5E5F20 /* CloudContentRecord.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -67,6 +68,10 @@ B27D7E45CCFE4FD48906C366 /* BooksTabView.swift */ = {isa = PBXFileReference; las
 24B1E4322B1ED1E200D9D1A8 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 24B1E4332B1ED1E200D9D1A8 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 24B1E4342B1ED1E200D9D1A8 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
+6C8F2F4A3B3F493A8E5E5F20 /* CloudContentRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudContentRecord.swift; sourceTree = "<group>"; };
+7A4D21894F99444CA9B2FC61 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+4F2D8C0F8A8B4A97B9927F31 /* PublicDatabaseSchema.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Schema/PublicDatabaseSchema.json; sourceTree = "<group>"; };
+B8D44E7E5E614B80A8DAE501 /* starry_forest_story.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Seed/Development/starry_forest_story.json; sourceTree = "<group>"; };
 9C1A5436E192431FAC27C24A /* Achievement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Achievement.swift; sourceTree = "<group>"; };
 227EE671A9F74842B81A1E5C /* AchievementRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementRegistry.swift; sourceTree = "<group>"; };
 8D3FD20C0F714F8C9175C7A1 /* AchievementsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementsViewModel.swift; sourceTree = "<group>"; };
@@ -242,12 +247,40 @@ sourceTree = "<group>";
     sourceTree = "<group>";
 };
 24B1E4092B1ED1E200D9D1A8 /* Cloud */ = {
-isa = PBXGroup;
-children = (
-24B1E4352B1ED1E200D9D1A8 /* .gitkeep */,
-);
-path = Cloud;
-sourceTree = "<group>";
+    isa = PBXGroup;
+    children = (
+        6C8F2F4A3B3F493A8E5E5F20 /* CloudContentRecord.swift */,
+        7A4D21894F99444CA9B2FC61 /* README.md */,
+        5B0E11C72907444C9E0F124F /* Schema */,
+        3E0B7C16D97F41E69BB3EAA8 /* Seed */,
+        24B1E4352B1ED1E200D9D1A8 /* .gitkeep */,
+    );
+    path = Cloud;
+    sourceTree = "<group>";
+};
+3E0B7C16D97F41E69BB3EAA8 /* Seed */ = {
+    isa = PBXGroup;
+    children = (
+        9D1F0B8E3D234C07A3770F58 /* Development */,
+    );
+    path = Seed;
+    sourceTree = "<group>";
+};
+5B0E11C72907444C9E0F124F /* Schema */ = {
+    isa = PBXGroup;
+    children = (
+        4F2D8C0F8A8B4A97B9927F31 /* PublicDatabaseSchema.json */,
+    );
+    path = Schema;
+    sourceTree = "<group>";
+};
+9D1F0B8E3D234C07A3770F58 /* Development */ = {
+    isa = PBXGroup;
+    children = (
+        B8D44E7E5E614B80A8DAE501 /* starry_forest_story.json */,
+    );
+    path = Development;
+    sourceTree = "<group>";
 };
 24B1E40A2B1ED1E200D9D1A8 /* Storage */ = {
     isa = PBXGroup;
@@ -421,6 +454,7 @@ buildActionMask = 2147483647;
         4CFA6382C3AA488EBAEF782D /* ReaderProgressStore.swift in Sources */,
         AB13F528B34449AC8CA83C9F /* ReaderRecordingStore.swift in Sources */,
         195983EEC1AA45BAA195F2A9 /* VocabularyStore.swift in Sources */,
+        E5F0C8A7A9E44929B0CF8F6D /* CloudContentRecord.swift in Sources */,
         4F6A7B8C9D0E1F2A3B4C5D6E /* UserProfileStore.swift in Sources */,
     );
     runOnlyForDeploymentPostprocessing = 0;

--- a/Bonfire/Cloud/CloudContentRecord.swift
+++ b/Bonfire/Cloud/CloudContentRecord.swift
@@ -1,0 +1,56 @@
+import CloudKit
+
+/// CloudKit record type names used for Public database content.
+enum CloudContentRecordType {
+    static let book = "Book"
+    static let page = "Page"
+    static let textVariant = "TextVariant"
+    static let dictionaryEntry = "DictionaryEntry"
+}
+
+/// Field keys for the `Book` record type stored in the Public database.
+enum CloudBookFields {
+    static let title = "title"
+    static let subtitle = "subtitle"
+    static let author = "author"
+    static let summary = "summary"
+    static let level = "level"
+    static let topic = "topic"
+    static let length = "length"
+    static let pageCount = "pageCount"
+}
+
+/// Field keys for the `Page` record type.
+enum CloudPageFields {
+    static let book = "book"
+    static let index = "index"
+    static let estimatedWordCount = "estimatedWordCount"
+}
+
+/// Field keys for the `TextVariant` record type.
+enum CloudTextVariantFields {
+    static let page = "page"
+    static let kind = "kind"
+    static let languageCode = "languageCode"
+    static let content = "content"
+    static let displayOrder = "displayOrder"
+}
+
+/// Field keys for the `DictionaryEntry` record type.
+enum CloudDictionaryEntryFields {
+    static let book = "book"
+    static let lemma = "lemma"
+    static let term = "term"
+    static let definition = "definition"
+    static let partOfSpeech = "partOfSpeech"
+    static let example = "example"
+    static let level = "level"
+    static let pageIndex = "pageIndex"
+}
+
+extension CKRecord {
+    /// Convenience accessor for resolving a book reference from a page or dictionary entry.
+    func bookReference(forKey key: String) -> CKRecord.Reference? {
+        object(forKey: key) as? CKRecord.Reference
+    }
+}

--- a/Bonfire/Cloud/README.md
+++ b/Bonfire/Cloud/README.md
@@ -1,0 +1,72 @@
+# CloudKit Content Schema
+
+This directory defines the CloudKit Public Database schema and seed content for Bonfire stories and dictionary data. The schema can be applied with `cktool` or the CloudKit dashboard, and the development seed can be imported to quickly populate the Development environment with a sample story.
+
+## Record Types
+
+### `Book`
+- **title** (`STRING`, searchable)
+- **subtitle** (`STRING`, optional, searchable)
+- **author** (`STRING`)
+- **summary** (`STRING`, searchable)
+- **level** (`STRING`, queryable filter)
+- **topic** (`STRING`)
+- **length** (`STRING`)
+- **pageCount** (`INT64`)
+
+_Indexes_
+- `by_level` — single-field index to support level filters in catalog queries.
+
+### `Page`
+- **book** (`REFERENCE` → `Book`)
+- **index** (`INT64`)
+- **estimatedWordCount** (`INT64`, optional)
+
+_Indexes_
+- `by_book` — fetch all pages for a book.
+- `by_book_index` — ordered fetch for pagination.
+
+### `TextVariant`
+- **page** (`REFERENCE` → `Page`)
+- **kind** (`STRING`, values: `original`, `translation`, `phonetic`)
+- **languageCode** (`STRING`, BCP-47)
+- **content** (`STRING`, searchable)
+- **displayOrder** (`INT64`)
+
+_Indexes_
+- `by_page` — fetch all variants of a page.
+- `by_page_language` — fetch a page variant for a specific language.
+
+### `DictionaryEntry`
+- **book** (`REFERENCE` → `Book`)
+- **lemma** (`STRING`, normalized key for lookup)
+- **term** (`STRING`, display form)
+- **definition** (`STRING`, searchable)
+- **partOfSpeech** (`STRING`)
+- **example** (`STRING`, optional, searchable)
+- **level** (`STRING`)
+- **pageIndex** (`INT64`, optional reference to first page use)
+
+_Indexes_
+- `by_book` — fetch all glossary terms for a story.
+- `by_lemma` — search by lemma/word (case-insensitive compares should be handled client-side).
+- `by_level` — support study sets filtered by CEFR level.
+
+## Seed Data
+
+The development seed `Seed/Development/starry_forest_story.json` contains a sample book titled _Starry Forest Adventure_ with three pages, multilingual text variants, and supporting dictionary entries. Importing this file into the Development environment will surface records in the CloudKit dashboard and allow the app to query content without exposing any learner PII.
+
+### Import Instructions
+
+1. Ensure you are authenticated for the `iCloud.com.bonefire.myapp` container.
+2. Apply the schema:
+   ```bash
+   cktool schema import --path Bonfire/Cloud/Schema/PublicDatabaseSchema.json --environment development
+   ```
+3. Import the development seed records:
+   ```bash
+   cktool record import --path Bonfire/Cloud/Seed/Development/starry_forest_story.json --environment development
+   ```
+4. Verify the records appear in the CloudKit Dashboard under the Public Database.
+
+> ℹ️ No child or learner personally identifiable information is stored in the Public database. All content records are static story assets.

--- a/Bonfire/Cloud/Schema/PublicDatabaseSchema.json
+++ b/Bonfire/Cloud/Schema/PublicDatabaseSchema.json
@@ -1,0 +1,96 @@
+{
+  "database": "Public",
+  "recordTypes": [
+    {
+      "name": "Book",
+      "fields": [
+        { "name": "title", "type": "STRING", "allowsFullTextSearch": true },
+        { "name": "subtitle", "type": "STRING", "optional": true, "allowsFullTextSearch": true },
+        { "name": "author", "type": "STRING" },
+        { "name": "summary", "type": "STRING", "allowsFullTextSearch": true },
+        { "name": "level", "type": "STRING" },
+        { "name": "topic", "type": "STRING" },
+        { "name": "length", "type": "STRING" },
+        { "name": "pageCount", "type": "INT64" }
+      ],
+      "indexes": [
+        {
+          "name": "by_level",
+          "fields": [ { "fieldName": "level", "ascending": true } ]
+        }
+      ]
+    },
+    {
+      "name": "Page",
+      "fields": [
+        { "name": "book", "type": "REFERENCE", "referenceType": "Book" },
+        { "name": "index", "type": "INT64" },
+        { "name": "estimatedWordCount", "type": "INT64", "optional": true }
+      ],
+      "indexes": [
+        {
+          "name": "by_book",
+          "fields": [ { "fieldName": "book", "ascending": true } ]
+        },
+        {
+          "name": "by_book_index",
+          "fields": [
+            { "fieldName": "book", "ascending": true },
+            { "fieldName": "index", "ascending": true }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "TextVariant",
+      "fields": [
+        { "name": "page", "type": "REFERENCE", "referenceType": "Page" },
+        { "name": "kind", "type": "STRING" },
+        { "name": "languageCode", "type": "STRING" },
+        { "name": "content", "type": "STRING", "allowsFullTextSearch": true },
+        { "name": "displayOrder", "type": "INT64" }
+      ],
+      "indexes": [
+        {
+          "name": "by_page",
+          "fields": [ { "fieldName": "page", "ascending": true } ]
+        },
+        {
+          "name": "by_page_language",
+          "fields": [
+            { "fieldName": "page", "ascending": true },
+            { "fieldName": "languageCode", "ascending": true }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "DictionaryEntry",
+      "fields": [
+        { "name": "book", "type": "REFERENCE", "referenceType": "Book" },
+        { "name": "lemma", "type": "STRING" },
+        { "name": "term", "type": "STRING" },
+        { "name": "definition", "type": "STRING", "allowsFullTextSearch": true },
+        { "name": "partOfSpeech", "type": "STRING" },
+        { "name": "example", "type": "STRING", "optional": true, "allowsFullTextSearch": true },
+        { "name": "level", "type": "STRING" },
+        { "name": "pageIndex", "type": "INT64", "optional": true }
+      ],
+      "indexes": [
+        {
+          "name": "by_book",
+          "fields": [ { "fieldName": "book", "ascending": true } ]
+        },
+        {
+          "name": "by_lemma",
+          "fields": [ { "fieldName": "lemma", "ascending": true } ],
+          "isUnique": false
+        },
+        {
+          "name": "by_level",
+          "fields": [ { "fieldName": "level", "ascending": true } ]
+        }
+      ]
+    }
+  ]
+}

--- a/Bonfire/Cloud/Seed/Development/starry_forest_story.json
+++ b/Bonfire/Cloud/Seed/Development/starry_forest_story.json
@@ -1,0 +1,296 @@
+{
+  "records": [
+    {
+      "recordName": "DEV_Book_StarryForestAdventure",
+      "recordType": "Book",
+      "fields": {
+        "title": { "value": "Starry Forest Adventure" },
+        "subtitle": { "value": "A Curious Fox Explores the Night" },
+        "author": { "value": "Bonfire Editorial" },
+        "summary": {
+          "value": "Mina the fox wakes before dawn to explore the glowing forest and gather her sleepy friends for sunrise."
+        },
+        "level": { "value": "A1" },
+        "topic": { "value": "adventure" },
+        "length": { "value": "short" },
+        "pageCount": { "value": 3 }
+      }
+    },
+    {
+      "recordName": "DEV_Page_StarryForest_0",
+      "recordType": "Page",
+      "fields": {
+        "book": {
+          "value": {
+            "recordName": "DEV_Book_StarryForestAdventure",
+            "zone": "_defaultZone",
+            "action": "NONE"
+          }
+        },
+        "index": { "value": 0 },
+        "estimatedWordCount": { "value": 22 }
+      }
+    },
+    {
+      "recordName": "DEV_Page_StarryForest_1",
+      "recordType": "Page",
+      "fields": {
+        "book": {
+          "value": {
+            "recordName": "DEV_Book_StarryForestAdventure",
+            "zone": "_defaultZone",
+            "action": "NONE"
+          }
+        },
+        "index": { "value": 1 },
+        "estimatedWordCount": { "value": 24 }
+      }
+    },
+    {
+      "recordName": "DEV_Page_StarryForest_2",
+      "recordType": "Page",
+      "fields": {
+        "book": {
+          "value": {
+            "recordName": "DEV_Book_StarryForestAdventure",
+            "zone": "_defaultZone",
+            "action": "NONE"
+          }
+        },
+        "index": { "value": 2 },
+        "estimatedWordCount": { "value": 23 }
+      }
+    },
+    {
+      "recordName": "DEV_TextVariant_StarryForest_0_original",
+      "recordType": "TextVariant",
+      "fields": {
+        "page": {
+          "value": {
+            "recordName": "DEV_Page_StarryForest_0",
+            "zone": "_defaultZone",
+            "action": "NONE"
+          }
+        },
+        "kind": { "value": "original" },
+        "languageCode": { "value": "en" },
+        "content": {
+          "value": "Mina the fox woke before sunrise, the forest still dressed in silver mist."
+        },
+        "displayOrder": { "value": 0 }
+      }
+    },
+    {
+      "recordName": "DEV_TextVariant_StarryForest_0_translation",
+      "recordType": "TextVariant",
+      "fields": {
+        "page": {
+          "value": {
+            "recordName": "DEV_Page_StarryForest_0",
+            "zone": "_defaultZone",
+            "action": "NONE"
+          }
+        },
+        "kind": { "value": "translation" },
+        "languageCode": { "value": "vi" },
+        "content": {
+          "value": "Cáo Mina thức dậy trước bình minh, khu rừng vẫn khoác màn sương bạc."
+        },
+        "displayOrder": { "value": 1 }
+      }
+    },
+    {
+      "recordName": "DEV_TextVariant_StarryForest_0_phonetic",
+      "recordType": "TextVariant",
+      "fields": {
+        "page": {
+          "value": {
+            "recordName": "DEV_Page_StarryForest_0",
+            "zone": "_defaultZone",
+            "action": "NONE"
+          }
+        },
+        "kind": { "value": "phonetic" },
+        "languageCode": { "value": "en-fonipa" },
+        "content": {
+          "value": "MEE-nah thuh fahks wohk bih-FOHR SUN-rise, thuh FAW-ruhst stihl drest in SIHL-vur mist."
+        },
+        "displayOrder": { "value": 2 }
+      }
+    },
+    {
+      "recordName": "DEV_TextVariant_StarryForest_1_original",
+      "recordType": "TextVariant",
+      "fields": {
+        "page": {
+          "value": {
+            "recordName": "DEV_Page_StarryForest_1",
+            "zone": "_defaultZone",
+            "action": "NONE"
+          }
+        },
+        "kind": { "value": "original" },
+        "languageCode": { "value": "en" },
+        "content": {
+          "value": "She lit a small lantern and followed fireflies toward the old cedar clearing."
+        },
+        "displayOrder": { "value": 0 }
+      }
+    },
+    {
+      "recordName": "DEV_TextVariant_StarryForest_1_translation",
+      "recordType": "TextVariant",
+      "fields": {
+        "page": {
+          "value": {
+            "recordName": "DEV_Page_StarryForest_1",
+            "zone": "_defaultZone",
+            "action": "NONE"
+          }
+        },
+        "kind": { "value": "translation" },
+        "languageCode": { "value": "vi" },
+        "content": {
+          "value": "Cô thắp một chiếc đèn lồng nhỏ và đi theo đàn đom đóm đến khoảng trống cây tuyết tùng."
+        },
+        "displayOrder": { "value": 1 }
+      }
+    },
+    {
+      "recordName": "DEV_TextVariant_StarryForest_1_phonetic",
+      "recordType": "TextVariant",
+      "fields": {
+        "page": {
+          "value": {
+            "recordName": "DEV_Page_StarryForest_1",
+            "zone": "_defaultZone",
+            "action": "NONE"
+          }
+        },
+        "kind": { "value": "phonetic" },
+        "languageCode": { "value": "en-fonipa" },
+        "content": {
+          "value": "Shee liht uh small LAN-turn and FAH-lohd FYR-flayz tuh-WAWRD thee ohld SEE-der KLEER-ing."
+        },
+        "displayOrder": { "value": 2 }
+      }
+    },
+    {
+      "recordName": "DEV_TextVariant_StarryForest_2_original",
+      "recordType": "TextVariant",
+      "fields": {
+        "page": {
+          "value": {
+            "recordName": "DEV_Page_StarryForest_2",
+            "zone": "_defaultZone",
+            "action": "NONE"
+          }
+        },
+        "kind": { "value": "original" },
+        "languageCode": { "value": "en" },
+        "content": {
+          "value": "There she found her friends yawning awake as dawn painted the sky with rose and gold."
+        },
+        "displayOrder": { "value": 0 }
+      }
+    },
+    {
+      "recordName": "DEV_TextVariant_StarryForest_2_translation",
+      "recordType": "TextVariant",
+      "fields": {
+        "page": {
+          "value": {
+            "recordName": "DEV_Page_StarryForest_2",
+            "zone": "_defaultZone",
+            "action": "NONE"
+          }
+        },
+        "kind": { "value": "translation" },
+        "languageCode": { "value": "vi" },
+        "content": {
+          "value": "Tại đó cô thấy bạn bè mình ngáp dài tỉnh dậy khi bình minh tô bầu trời bằng sắc hồng và vàng."
+        },
+        "displayOrder": { "value": 1 }
+      }
+    },
+    {
+      "recordName": "DEV_TextVariant_StarryForest_2_phonetic",
+      "recordType": "TextVariant",
+      "fields": {
+        "page": {
+          "value": {
+            "recordName": "DEV_Page_StarryForest_2",
+            "zone": "_defaultZone",
+            "action": "NONE"
+          }
+        },
+        "kind": { "value": "phonetic" },
+        "languageCode": { "value": "en-fonipa" },
+        "content": {
+          "value": "THAIR shee found her frendz YAWN-ing uh-WAYK az DAWN PAYN-ted thuh SKY with ROHZ and GOHLD."
+        },
+        "displayOrder": { "value": 2 }
+      }
+    },
+    {
+      "recordName": "DEV_Dictionary_StarryForest_Lantern",
+      "recordType": "DictionaryEntry",
+      "fields": {
+        "book": {
+          "value": {
+            "recordName": "DEV_Book_StarryForestAdventure",
+            "zone": "_defaultZone",
+            "action": "NONE"
+          }
+        },
+        "lemma": { "value": "lantern" },
+        "term": { "value": "lantern" },
+        "definition": { "value": "A light that can be carried, often protected by glass." },
+        "partOfSpeech": { "value": "noun" },
+        "example": { "value": "She lit a small lantern before leaving the den." },
+        "level": { "value": "A1" },
+        "pageIndex": { "value": 1 }
+      }
+    },
+    {
+      "recordName": "DEV_Dictionary_StarryForest_Clearing",
+      "recordType": "DictionaryEntry",
+      "fields": {
+        "book": {
+          "value": {
+            "recordName": "DEV_Book_StarryForestAdventure",
+            "zone": "_defaultZone",
+            "action": "NONE"
+          }
+        },
+        "lemma": { "value": "clearing" },
+        "term": { "value": "clearing" },
+        "definition": { "value": "An open space in a forest where there are no trees." },
+        "partOfSpeech": { "value": "noun" },
+        "example": { "value": "Fireflies led her to the old cedar clearing." },
+        "level": { "value": "A2" },
+        "pageIndex": { "value": 1 }
+      }
+    },
+    {
+      "recordName": "DEV_Dictionary_StarryForest_Dawn",
+      "recordType": "DictionaryEntry",
+      "fields": {
+        "book": {
+          "value": {
+            "recordName": "DEV_Book_StarryForestAdventure",
+            "zone": "_defaultZone",
+            "action": "NONE"
+          }
+        },
+        "lemma": { "value": "dawn" },
+        "term": { "value": "dawn" },
+        "definition": { "value": "The time of day when light first appears in the morning." },
+        "partOfSpeech": { "value": "noun" },
+        "example": { "value": "They gathered as dawn painted the sky." },
+        "level": { "value": "A1" },
+        "pageIndex": { "value": 2 }
+      }
+    }
+  ]
+}

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -18,3 +18,11 @@
 - Create a `Docs/` folder with this spec exported as README section headings.
 - Constraints: No binary assets checked in except placeholder textures.
 - Acceptance Criteria: Repo initialized; README references app IDs; branching rules documented.
+
+# Prompt 24 — CloudKit Schema (PublicDB Content)
+
+- Define Public database record types `Book`, `Page`, `TextVariant`, and `DictionaryEntry` with the fields described in the spec.
+- Add indexes to support common queries: book references, CEFR level filters, page ordering, and dictionary lemma lookups.
+- Seed the development environment with the sample story for testing.
+- Constraints: No learner or child PII stored in PublicDB.
+- Acceptance Criteria: Records and indexes appear in CloudKit Dashboard; development builds can query seeded content.


### PR DESCRIPTION
## Summary
- define PublicDB record types for books, pages, text variants, and dictionary entries
- document CloudKit schema, indexes, and import steps for the development environment
- seed the development database with the Starry Forest Adventure example story content

## Testing
- not run (schema and documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68dca252e780833195547705c38c8b91