### PR TITLE
feat: define private CloudKit user schema

### DIFF
--- a/Bonfire/Cloud/CloudUserRecord.swift
+++ b/Bonfire/Cloud/CloudUserRecord.swift
@@ -1,0 +1,63 @@
+import CloudKit
+
+/// CloudKit record type names used for Private database user data.
+enum CloudUserRecordType {
+    static let userProfile = "UserProfile"
+    static let readingSession = "ReadingSession"
+    static let wordProgress = "WordProgress"
+    static let achievement = "Achievement"
+    static let bookProgress = "BookProgress"
+}
+
+/// Field keys for the `UserProfile` record type stored in the Private database.
+enum CloudUserProfileFields {
+    static let displayName = "displayName"
+    static let preferredLocale = "preferredLocale"
+    static let readingStreak = "readingStreak"
+    static let lastSessionAt = "lastSessionAt"
+}
+
+/// Field keys for the `ReadingSession` record type.
+enum CloudReadingSessionFields {
+    static let user = "user"
+    static let book = "book"
+    static let startedAt = "startedAt"
+    static let endedAt = "endedAt"
+    static let durationSeconds = "durationSeconds"
+    static let wordsRead = "wordsRead"
+    static let startPageIndex = "startPageIndex"
+    static let endPageIndex = "endPageIndex"
+    static let audioAsset = "audioAsset"
+    static let notes = "notes"
+}
+
+/// Field keys for the `WordProgress` record type.
+enum CloudWordProgressFields {
+    static let user = "user"
+    static let book = "book"
+    static let lemma = "lemma"
+    static let proficiency = "proficiency"
+    static let correctCount = "correctCount"
+    static let incorrectCount = "incorrectCount"
+    static let lastReviewedAt = "lastReviewedAt"
+}
+
+/// Field keys for the `Achievement` record type.
+enum CloudAchievementFields {
+    static let user = "user"
+    static let code = "code"
+    static let earnedAt = "earnedAt"
+    static let progressValue = "progressValue"
+    static let detail = "detail"
+}
+
+/// Field keys for the `BookProgress` record type.
+enum CloudBookProgressFields {
+    static let user = "user"
+    static let book = "book"
+    static let lastPageIndex = "lastPageIndex"
+    static let percentComplete = "percentComplete"
+    static let lastOpenedAt = "lastOpenedAt"
+    static let completedAt = "completedAt"
+}
+

--- a/Bonfire/Cloud/README.md
+++ b/Bonfire/Cloud/README.md
@@ -1,6 +1,6 @@
 # CloudKit Content Schema
 
-This directory defines the CloudKit Public Database schema and seed content for Bonfire stories and dictionary data. The schema can be applied with `cktool` or the CloudKit dashboard, and the development seed can be imported to quickly populate the Development environment with a sample story.
+This directory defines the CloudKit schemas that power Bonfire. The Public database hosts shared story content, while the Private database captures each learner's progress, session history, and earned achievements. Schemas can be applied with `cktool` or the CloudKit dashboard, and the development seed can be imported to quickly populate the Development environment with a sample story.
 
 ## Record Types
 
@@ -70,3 +70,109 @@ The development seed `Seed/Development/starry_forest_story.json` contains a samp
 4. Verify the records appear in the CloudKit Dashboard under the Public Database.
 
 > ℹ️ No child or learner personally identifiable information is stored in the Public database. All content records are static story assets.
+
+## Private Database (User Data)
+
+The Private database captures per-user learning state. All record types live in the default zone of `CKContainer(identifier: "iCloud.com.bonefire.myapp")`.
+
+### Schema Overview
+
+- `UserProfile`
+  - **displayName** (`STRING`, optional, searchable)
+  - **preferredLocale** (`STRING`)
+  - **readingStreak** (`INT64`)
+  - **lastSessionAt** (`TIMESTAMP`, optional)
+  - _Index_: `by_locale` for filtering preferred locales (used sparingly for analytics aggregates).
+- `ReadingSession`
+  - **user** (`REFERENCE` → `UserProfile`)
+  - **book** (`REFERENCE` → Public `Book`, optional)
+  - **startedAt** (`TIMESTAMP`)
+  - **endedAt** (`TIMESTAMP`, optional)
+  - **durationSeconds** (`INT64`)
+  - **wordsRead** (`INT64`, optional)
+  - **startPageIndex** (`INT64`, optional)
+  - **endPageIndex** (`INT64`, optional)
+  - **audioAsset** (`ASSET`, optional, private audio recording of the session)
+  - **notes** (`STRING`, optional, searchable)
+  - _Indexes_: `by_user_startedAt`, `by_book_startedAt` for timeline and recap queries.
+- `WordProgress`
+  - **user** (`REFERENCE` → `UserProfile`)
+  - **book** (`REFERENCE` → `Book`, optional)
+  - **lemma** (`STRING`)
+  - **proficiency** (`DOUBLE`)
+  - **correctCount** (`INT64`)
+  - **incorrectCount** (`INT64`)
+  - **lastReviewedAt** (`TIMESTAMP`, optional)
+  - _Indexes_: `by_user_lemma`, `by_book` for targeted drills and book review summaries.
+- `Achievement`
+  - **user** (`REFERENCE` → `UserProfile`)
+  - **code** (`STRING`)
+  - **earnedAt** (`TIMESTAMP`)
+  - **progressValue** (`DOUBLE`, optional)
+  - **detail** (`STRING`, optional, searchable)
+  - _Indexes_: `by_user_code`, `by_user_earnedAt` for unlocking and ordering badges.
+- `BookProgress`
+  - **user** (`REFERENCE` → `UserProfile`)
+  - **book** (`REFERENCE` → `Book`)
+  - **lastPageIndex** (`INT64`)
+  - **percentComplete** (`DOUBLE`)
+  - **lastOpenedAt** (`TIMESTAMP`, optional)
+  - **completedAt** (`TIMESTAMP`, optional)
+  - _Indexes_: `by_user_book`, `by_user_lastOpened` for syncing library shelves.
+
+### Applying the Private Schema
+
+```bash
+cktool schema import --path Bonfire/Cloud/Schema/PrivateDatabaseSchema.json --environment development --database private
+```
+
+### Save Policies
+
+Use `CKModifyRecordsOperation` with the following save policies to avoid overwriting concurrent user changes:
+
+| Record Type    | Save Policy                   | Rationale |
+| -------------- | ----------------------------- | --------- |
+| `UserProfile`  | `.ifServerRecordUnchanged`    | Preserve streak counters and locale if another device updated the profile. |
+| `ReadingSession` | `.ifServerRecordUnchanged`  | Sessions are append-only; this prevents duplicate writes when retrying. |
+| `WordProgress` | `.changedKeys`                | Allows partial updates to spaced-repetition metrics without resending unchanged counters. |
+| `Achievement`  | `.ifServerRecordUnchanged`    | Avoids double-awarding a badge when syncing across devices. |
+| `BookProgress` | `.changedKeys`                | Merge granular reading position changes while letting CloudKit handle conflict resolution per field. |
+
+### Audio Asset Handling
+
+- Session recordings are stored in the `audioAsset` field of `ReadingSession`. Because the asset lives in the Private database, it is only accessible to the signed-in learner.
+- To delete a recording, clear the field and submit the change:
+
+  ```swift
+  readingSessionRecord[CloudReadingSessionFields.audioAsset] = nil
+  let operation = CKModifyRecordsOperation(recordsToSave: [readingSessionRecord], recordIDsToDelete: nil)
+  operation.savePolicy = .ifServerRecordUnchanged
+  database.add(operation)
+  ```
+
+  CloudKit removes the stored asset from the user's private container once the modification succeeds. Mirror this change locally by deleting any cached audio file in the app's sandbox (e.g., `Library/Application Support/ReadingSessions/<recordName>.m4a`).
+
+### Dummy Session Smoke Test
+
+Use the snippet below to create and read back a placeholder session after applying the schema on device:
+
+```swift
+let container = CKContainer(identifier: "iCloud.com.bonefire.myapp")
+let database = container.privateCloudDatabase
+
+let userRecordID = CKRecord.ID(recordName: "current-user")
+let session = CKRecord(recordType: CloudUserRecordType.readingSession)
+session[CloudReadingSessionFields.user] = CKRecord.Reference(recordID: userRecordID, action: .none)
+session[CloudReadingSessionFields.startedAt] = Date()
+session[CloudReadingSessionFields.durationSeconds] = 600
+
+database.save(session) { record, error in
+    guard let record else { return }
+
+    database.fetch(withRecordID: record.recordID) { fetched, _ in
+        print("Fetched session: \(fetched?.recordID.recordName ?? "<missing>")")
+    }
+}
+```
+
+The call saves a dummy `ReadingSession` and immediately retrieves it, satisfying the acceptance criteria for on-device verification.

--- a/Bonfire/Cloud/Schema/PrivateDatabaseSchema.json
+++ b/Bonfire/Cloud/Schema/PrivateDatabaseSchema.json
@@ -1,0 +1,129 @@
+{
+  "database": "Private",
+  "recordTypes": [
+    {
+      "name": "UserProfile",
+      "fields": [
+        { "name": "displayName", "type": "STRING", "optional": true, "allowsFullTextSearch": true },
+        { "name": "preferredLocale", "type": "STRING" },
+        { "name": "readingStreak", "type": "INT64" },
+        { "name": "lastSessionAt", "type": "TIMESTAMP", "optional": true }
+      ],
+      "indexes": [
+        {
+          "name": "by_locale",
+          "fields": [ { "fieldName": "preferredLocale", "ascending": true } ]
+        }
+      ]
+    },
+    {
+      "name": "ReadingSession",
+      "fields": [
+        { "name": "user", "type": "REFERENCE", "referenceType": "UserProfile" },
+        { "name": "book", "type": "REFERENCE", "referenceType": "Book", "optional": true },
+        { "name": "startedAt", "type": "TIMESTAMP" },
+        { "name": "endedAt", "type": "TIMESTAMP", "optional": true },
+        { "name": "durationSeconds", "type": "INT64" },
+        { "name": "wordsRead", "type": "INT64", "optional": true },
+        { "name": "startPageIndex", "type": "INT64", "optional": true },
+        { "name": "endPageIndex", "type": "INT64", "optional": true },
+        { "name": "audioAsset", "type": "ASSET", "optional": true },
+        { "name": "notes", "type": "STRING", "optional": true, "allowsFullTextSearch": true }
+      ],
+      "indexes": [
+        {
+          "name": "by_user_startedAt",
+          "fields": [
+            { "fieldName": "user", "ascending": true },
+            { "fieldName": "startedAt", "ascending": false }
+          ]
+        },
+        {
+          "name": "by_book_startedAt",
+          "fields": [
+            { "fieldName": "book", "ascending": true },
+            { "fieldName": "startedAt", "ascending": false }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "WordProgress",
+      "fields": [
+        { "name": "user", "type": "REFERENCE", "referenceType": "UserProfile" },
+        { "name": "book", "type": "REFERENCE", "referenceType": "Book", "optional": true },
+        { "name": "lemma", "type": "STRING" },
+        { "name": "proficiency", "type": "DOUBLE" },
+        { "name": "correctCount", "type": "INT64" },
+        { "name": "incorrectCount", "type": "INT64" },
+        { "name": "lastReviewedAt", "type": "TIMESTAMP", "optional": true }
+      ],
+      "indexes": [
+        {
+          "name": "by_user_lemma",
+          "fields": [
+            { "fieldName": "user", "ascending": true },
+            { "fieldName": "lemma", "ascending": true }
+          ]
+        },
+        {
+          "name": "by_book",
+          "fields": [ { "fieldName": "book", "ascending": true } ]
+        }
+      ]
+    },
+    {
+      "name": "Achievement",
+      "fields": [
+        { "name": "user", "type": "REFERENCE", "referenceType": "UserProfile" },
+        { "name": "code", "type": "STRING" },
+        { "name": "earnedAt", "type": "TIMESTAMP" },
+        { "name": "progressValue", "type": "DOUBLE", "optional": true },
+        { "name": "detail", "type": "STRING", "optional": true, "allowsFullTextSearch": true }
+      ],
+      "indexes": [
+        {
+          "name": "by_user_code",
+          "fields": [
+            { "fieldName": "user", "ascending": true },
+            { "fieldName": "code", "ascending": true }
+          ]
+        },
+        {
+          "name": "by_user_earnedAt",
+          "fields": [
+            { "fieldName": "user", "ascending": true },
+            { "fieldName": "earnedAt", "ascending": false }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "BookProgress",
+      "fields": [
+        { "name": "user", "type": "REFERENCE", "referenceType": "UserProfile" },
+        { "name": "book", "type": "REFERENCE", "referenceType": "Book" },
+        { "name": "lastPageIndex", "type": "INT64" },
+        { "name": "percentComplete", "type": "DOUBLE" },
+        { "name": "lastOpenedAt", "type": "TIMESTAMP", "optional": true },
+        { "name": "completedAt", "type": "TIMESTAMP", "optional": true }
+      ],
+      "indexes": [
+        {
+          "name": "by_user_book",
+          "fields": [
+            { "fieldName": "user", "ascending": true },
+            { "fieldName": "book", "ascending": true }
+          ]
+        },
+        {
+          "name": "by_user_lastOpened",
+          "fields": [
+            { "fieldName": "user", "ascending": true },
+            { "fieldName": "lastOpenedAt", "ascending": false }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -26,3 +26,11 @@
 - Seed the development environment with the sample story for testing.
 - Constraints: No learner or child PII stored in PublicDB.
 - Acceptance Criteria: Records and indexes appear in CloudKit Dashboard; development builds can query seeded content.
+
+# Prompt 25 — CloudKit Schema (PrivateDB User Data)
+
+- Create Private database record types `UserProfile`, `ReadingSession`, `WordProgress`, `Achievement`, and `BookProgress` with per-field data types.
+- Document save policies for each type to avoid clobbering concurrent edits.
+- Ensure audio recordings are stored as Private database assets and describe the deletion flow.
+- Constraints: Audio files must remain private to the learner; provide a safe removal path for uploaded assets.
+- Acceptance Criteria: A dummy `ReadingSession` record can be written and fetched on device using the new schema.


### PR DESCRIPTION
## Summary
- add CloudKit Private database schema covering user profile, sessions, vocab progress, achievements, and book progress records
- document save policies, audio asset handling, and dummy session verification workflow for PrivateDB
- expose record type and field keys in code for app use and note the new prompt requirements in the docs

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dca64eab488331a6ff64db6a393de6