### PR TITLE
Add App Store launch preparation materials

### DIFF
--- a/Docs/AppStore/Metadata/AgeRatingResponses.md
+++ b/Docs/AppStore/Metadata/AgeRatingResponses.md
@@ -1,0 +1,33 @@
+# Age Rating Questionnaire — Bonfire
+
+- **Bundle Identifier:** com.bon.bonfire
+- **Team ID:** 59Q6X62P3A
+- **iCloud Container:** iCloud.com.bonefire.myapp
+
+The following responses align with Apple's age rating questionnaire and should result in a "4+" rating. Review before submission if content changes.
+
+| Topic | Question | Answer |
+|-------|----------|--------|
+| Violence | Cartoon or fantasy violence? | No |
+| Violence | Realistic violence? | No |
+| Violence | Prolonged or intense violence? | No |
+| Horror/Fear | Horror or fear themes? | No |
+| Mature/Suggestive | Profanity or crude humor? | No |
+| Mature/Suggestive | Sexual content or nudity? | No |
+| Mature/Suggestive | Alcohol, tobacco, or drug use? | No |
+| Gambling | Simulated gambling? | No |
+| Contests | Contests or sweepstakes? | No |
+| Education | Medical or treatment information? | No |
+| User Generated | User-generated content? | Yes — limited to private story recordings shared within approved circles. |
+| User Generated | Frequent/intense? | No |
+| User Generated | Public exposure? | No |
+| Social Features | Account-based social networking? | No |
+| Social Features | Unrestricted web access? | No |
+| Social Features | Purchase history or location? | No |
+| Kids Category | Includes third-party analytics? | No |
+| Kids Category | Links out of the app? | No |
+| Kids Category | Collects personal info? | No |
+
+## Notes
+- Story recordings and vocabulary progress sync via CloudKit within the iCloud.com.bonefire.myapp container. Access is limited to trusted members added by a parent or educator.
+- Ensure parental gates are present before leaving the app or accessing teacher settings.

--- a/Docs/AppStore/Metadata/PrivacyNutritionLabel.md
+++ b/Docs/AppStore/Metadata/PrivacyNutritionLabel.md
@@ -1,0 +1,22 @@
+# Privacy Nutrition Label — Bonfire
+
+- **Bundle Identifier:** com.bon.bonfire
+- **Team ID:** 59Q6X62P3A
+- **iCloud Container:** iCloud.com.bonefire.myapp
+
+Bonfire uses Apple's privacy nutrition label format. The following data collection summary reflects the current feature set and should be updated before submission if functionality changes.
+
+## Data Collection Overview
+| Data Type | Collected? | Linked to User? | Used for Tracking? | Purpose |
+|-----------|------------|-----------------|--------------------|---------|
+| Microphone Audio | No* | — | — | Optional story narration recording feature remains on-device unless user opts to share. |
+| User Content (Story Recordings) | Yes | Yes | No | Stored securely in iCloud.com.bonefire.myapp to sync narration clips across approved devices. |
+| Diagnostics | Yes | No | No | Anonymous crash logs via Apple to improve stability. |
+
+> \* Request microphone permission only when a reader starts recording. Provide clear in-app guidance for families.
+
+## Data Not Collected
+Bonfire does **not** collect contact information, health and fitness data, financial data, or sensitive information. No third-party advertising SDKs are integrated.
+
+## Developer Privacy Policy URL
+https://bonfire.example.com/privacy

--- a/Docs/AppStore/Metadata/ScreenshotChecklist.md
+++ b/Docs/AppStore/Metadata/ScreenshotChecklist.md
@@ -1,0 +1,26 @@
+# Screenshot Capture Checklist — Bonfire
+
+- **Bundle Identifier:** com.bon.bonfire
+- **Team ID:** 59Q6X62P3A
+- **iCloud Container:** iCloud.com.bonefire.myapp
+
+Capture device-specific screenshots in both light and dark appearances. Keep copy friendly for parents, teachers, and students.
+
+## Mandatory Devices
+1. **6.7" iPhone (Pro Max)** — showcase interactive story spread with vocabulary pop-ups.
+2. **6.1" iPhone (Pro)** — highlight cooperative circle selection screen.
+3. **12.9" iPad Pro** — display educator dashboard with progress badges.
+4. **11" iPad Pro** — feature collaborative vocabulary game.
+5. **App Preview (Optional)** — short video of a story session with narration cue.
+
+## Scene Checklist
+- [ ] Welcome screen with "Gather around the fire" headline.
+- [ ] Story circle selection showing avatars in a friendly camp setting.
+- [ ] Vocabulary mini-game demonstrating word discovery.
+- [ ] Reading progress tracker with CloudKit sync badge.
+- [ ] Parent/teacher settings panel showing privacy reassurance.
+
+## Export Notes
+- Use native device resolutions per App Store Connect requirements.
+- Localize captions for English and Vietnamese markets.
+- Remove personal data before capture; use classroom-safe names and avatars.

--- a/Docs/AppStore/Metadata/SubtitlesAndKeywords.md
+++ b/Docs/AppStore/Metadata/SubtitlesAndKeywords.md
@@ -1,0 +1,26 @@
+# Subtitle & Keyword Options — Bonfire
+
+- **Bundle Identifier:** com.bon.bonfire
+- **Team ID:** 59Q6X62P3A
+- **iCloud Container:** iCloud.com.bonefire.myapp
+
+## Subtitle Concepts
+1. **Campfire stories that build confident readers**
+2. **Gather around to read, share, and shine**
+3. **Vocabulary adventures for every story circle**
+
+Each option aligns with the Bonfire theme while remaining parent-friendly and appropriate for school communities.
+
+## Keyword Set (English Locale)
+1. campfire tales
+2. story circle
+3. reading games
+4. vocabulary quests
+5. guided reading
+6. literacy adventures
+7. classroom stories
+8. family reading
+9. kids vocabulary
+10. cooperative reading
+
+Use these keywords in App Store Connect (separated by commas) to target search terms related to collaborative reading and vocabulary growth.

--- a/Docs/AppStore/Metadata/en-US.md
+++ b/Docs/AppStore/Metadata/en-US.md
@@ -1,0 +1,25 @@
+# Bonfire App Store Metadata — English (U.S.)
+
+- **Bundle Identifier:** com.bon.bonfire
+- **Team ID:** 59Q6X62P3A
+- **iCloud Container:** iCloud.com.bonefire.myapp
+
+## Subtitle (Primary)
+Campfire stories that build confident readers
+
+## Description
+Welcome to Bonfire, the cozy reading circle where families and classrooms discover fresh tales together. Gather around interactive stories, practice new vocabulary, and spark thoughtful conversations with gentle prompts designed for curious minds.
+
+Bonfire keeps reading time friendly and safe. Educators can form story circles, track progress through the secure CloudKit sync, and celebrate every milestone with encouraging badges. Whether it is bedtime or group time, Bonfire helps every reader glow a little brighter.
+
+## Promotional Text Placeholder
+Share a short seasonal message here highlighting the newest story pack or vocabulary adventure.
+
+## Keywords (English)
+campfire tales, story circle, reading games, vocabulary quests, guided reading, literacy adventures, classroom stories, family reading, kids vocabulary, cooperative reading
+
+## Support URL
+https://bonfire.example.com/support
+
+## Marketing URL
+https://bonfire.example.com

--- a/Docs/AppStore/Metadata/vi.md
+++ b/Docs/AppStore/Metadata/vi.md
@@ -1,0 +1,25 @@
+# Thông Tin App Store Bonfire — Tiếng Việt
+
+- **Bundle Identifier:** com.bon.bonfire
+- **Team ID:** 59Q6X62P3A
+- **iCloud Container:** iCloud.com.bonefire.myapp
+
+## Phụ đề (Chính)
+Vòng tròn kể chuyện giúp bé yêu đọc sách
+
+## Mô tả
+Bonfire là vòng tròn đọc sách ấm áp, nơi gia đình và lớp học cùng khám phá những câu chuyện mới mỗi ngày. Cùng quây quần bên đống lửa, tương tác với truyện tranh, luyện từ vựng mới và trò chuyện với những gợi ý nhẹ nhàng dành cho các bạn nhỏ tò mò.
+
+Bonfire giữ cho giờ đọc sách luôn thân thiện và an toàn. Giáo viên có thể tạo nhóm kể chuyện, theo dõi tiến độ qua đồng bộ CloudKit bảo mật và chúc mừng từng cột mốc bằng những huy hiệu khích lệ. Dù là giờ đi ngủ hay giờ sinh hoạt lớp, Bonfire giúp mỗi độc giả nhỏ tỏa sáng hơn.
+
+## Văn bản quảng bá (placeholder)
+Thêm thông điệp ngắn theo mùa tại đây để giới thiệu gói truyện hoặc hành trình từ vựng mới nhất.
+
+## Từ khóa (Tiếng Việt)
+truyện quanh lửa trại, vòng tròn kể chuyện, trò chơi đọc sách, hành trình từ vựng, đọc hiểu có hướng dẫn, phiêu lưu ngôn ngữ, truyện lớp học, đọc sách gia đình, từ vựng cho trẻ, đọc sách cùng nhau
+
+## Đường dẫn hỗ trợ
+https://bonfire.example.com/support
+
+## Đường dẫn tiếp thị
+https://bonfire.example.com

--- a/Docs/AppStore/Placeholders/AppIcon.appiconset/README.md
+++ b/Docs/AppStore/Placeholders/AppIcon.appiconset/README.md
@@ -1,0 +1,22 @@
+# Bonfire App Icon Placeholder
+
+- **Bundle Identifier:** com.bon.bonfire
+- **Team ID:** 59Q6X62P3A
+- **iCloud Container:** iCloud.com.bonefire.myapp
+
+This directory reserves space for the production-ready app icon asset catalog.
+
+## Required Icon Sizes
+| Usage | Size (px) | Scale |
+|-------|-----------|-------|
+| App Store (marketing) | 1024×1024 | @1x |
+| iPhone notification | 60×60 | @2x, @3x |
+| iPhone app icon | 60×60 | @2x, @3x |
+| iPhone Spotlight | 40×40 | @2x, @3x |
+| iPad notification | 20×20 | @1x, @2x |
+| iPad Spotlight | 40×40 | @1x, @2x |
+| iPad app icon | 76×76 | @1x, @2x |
+| iPad Pro (12.9") | 83.5×83.5 | @2x |
+| App Store (iOS/iPadOS) | 1024×1024 | @1x |
+
+> Replace this placeholder with production PNG assets sized for each slot. Ensure visuals reflect Bonfire's campfire storytelling theme and remain welcoming for families and classrooms.

--- a/Docs/AppStore/Placeholders/LaunchScreenPlaceholder.md
+++ b/Docs/AppStore/Placeholders/LaunchScreenPlaceholder.md
@@ -1,0 +1,15 @@
+# Launch Screen Placeholder
+
+- **Bundle Identifier:** com.bon.bonfire
+- **Team ID:** 59Q6X62P3A
+- **iCloud Container:** iCloud.com.bonefire.myapp
+
+## Concept
+Display an illustrated campfire circle with warm gradients and softly glowing embers. Include the Bonfire logotype centered above a short tagline:
+
+> "Gather, read, and grow together."
+
+## Production Checklist
+- [ ] Export universal storyboard or SwiftUI launch screen referencing the final art.
+- [ ] Confirm accessibility contrast ratios meet WCAG AA.
+- [ ] Keep imagery school-safe and welcoming for young readers and educators.

--- a/Docs/AppStore/SubmissionChecklist.md
+++ b/Docs/AppStore/SubmissionChecklist.md
@@ -1,0 +1,33 @@
+# Bonfire App Store Submission Checklist
+
+- **Bundle Identifier:** com.bon.bonfire
+- **Team ID:** 59Q6X62P3A
+- **iCloud Container:** iCloud.com.bonefire.myapp
+
+## Assets & Visuals
+- [ ] Finalize app icon assets replacing `Docs/AppStore/Placeholders/AppIcon.appiconset`.
+- [ ] Complete universal launch screen implementation following `Docs/AppStore/Placeholders/LaunchScreenPlaceholder.md`.
+- [ ] Capture and upload screenshots per `Docs/AppStore/Metadata/ScreenshotChecklist.md`.
+
+## Metadata
+- [ ] Confirm English metadata in `Docs/AppStore/Metadata/en-US.md`.
+- [ ] Confirm Vietnamese metadata in `Docs/AppStore/Metadata/vi.md`.
+- [ ] Select final subtitle from `Docs/AppStore/Metadata/SubtitlesAndKeywords.md`.
+- [ ] Update privacy label details if data practices change (`Docs/AppStore/Metadata/PrivacyNutritionLabel.md`).
+- [ ] Review age rating answers in `Docs/AppStore/Metadata/AgeRatingResponses.md`.
+
+## App Store Connect Configuration
+- [ ] Bundle ID: **com.bon.bonfire**
+- [ ] Team ID: **59Q6X62P3A**
+- [ ] iCloud Container: **iCloud.com.bonefire.myapp**
+- [ ] Enable CloudKit containers and capabilities in Xcode and App Store Connect.
+- [ ] Upload build via Xcode using matching provisioning profiles.
+
+## Compliance
+- [ ] Confirm microphone usage description in `Info.plist` explains optional narration recording.
+- [ ] Verify privacy policy URL (https://bonfire.example.com/privacy) is live and accessible.
+- [ ] Ensure in-app purchases, if any, are configured and tested.
+- [ ] Run final QA on devices covering English and Vietnamese content.
+
+## Ready to Submit
+Check every item above, then complete App Store Connect submission forms, including pricing, release timing, and contact information for review notes.


### PR DESCRIPTION
## Summary
- add placeholder assets and guidance for the Bonfire app icon and launch screen
- document localized App Store metadata, subtitles, keywords, and privacy details
- capture submission checklist items including age rating responses and screenshot plan

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcb9b55d388331aa6e3f3493d287ae