### PR TITLE
Add SwiftData fallbacks for iOS 16 builds

### DIFF
--- a/Bonfire/Storage/PrivateSyncModels.swift
+++ b/Bonfire/Storage/PrivateSyncModels.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(SwiftData)
 import SwiftData
+#endif
 
 enum PrivateRecordType: String, Codable, Sendable {
     case userProfile
@@ -128,6 +130,7 @@ struct BookProgressSnapshot: Codable, Sendable {
     var modifiedAt: Date
 }
 
+#if canImport(SwiftData)
 @Model final class UserProfileEntity {
     @Attribute(.unique) var recordName: String
     var displayName: String?
@@ -356,3 +359,4 @@ struct BookProgressSnapshot: Codable, Sendable {
         )
     }
 }
+#endif


### PR DESCRIPTION
## Summary
- guard SwiftData model declarations so the app no longer requires SwiftData when building for iOS 16
- add a lightweight PrivateSyncCoordinator fallback that queues sync envelopes without relying on SwiftData

## Testing
- Not run (Xcode not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dcc99784cc833184a35e5dc1f421f3